### PR TITLE
"Group By" drag-and-drop bug fixes, and remove unnecessary console logs.

### DIFF
--- a/dist/components/index.js
+++ b/dist/components/index.js
@@ -1,7 +1,6 @@
 "use strict";
 
 var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
-
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
@@ -29,18 +28,6 @@ Object.defineProperty(exports, "MTableBodyRow", {
     return _mTableBodyRow["default"];
   }
 });
-Object.defineProperty(exports, "MTableGroupbar", {
-  enumerable: true,
-  get: function get() {
-    return _mTableGroupbar["default"];
-  }
-});
-Object.defineProperty(exports, "MTableGroupRow", {
-  enumerable: true,
-  get: function get() {
-    return _mTableGroupRow["default"];
-  }
-});
 Object.defineProperty(exports, "MTableCell", {
   enumerable: true,
   get: function get() {
@@ -53,22 +40,34 @@ Object.defineProperty(exports, "MTableEditCell", {
     return _mTableEditCell["default"];
   }
 });
-Object.defineProperty(exports, "MTableEditRow", {
-  enumerable: true,
-  get: function get() {
-    return _mTableEditRow["default"];
-  }
-});
 Object.defineProperty(exports, "MTableEditField", {
   enumerable: true,
   get: function get() {
     return _mTableEditField["default"];
   }
 });
+Object.defineProperty(exports, "MTableEditRow", {
+  enumerable: true,
+  get: function get() {
+    return _mTableEditRow["default"];
+  }
+});
 Object.defineProperty(exports, "MTableFilterRow", {
   enumerable: true,
   get: function get() {
     return _mTableFilterRow["default"];
+  }
+});
+Object.defineProperty(exports, "MTableGroupRow", {
+  enumerable: true,
+  get: function get() {
+    return _mTableGroupRow["default"];
+  }
+});
+Object.defineProperty(exports, "MTableGroupbar", {
+  enumerable: true,
+  get: function get() {
+    return _mTableGroupbar["default"];
   }
 });
 Object.defineProperty(exports, "MTableHeader", {
@@ -95,33 +94,18 @@ Object.defineProperty(exports, "MTableToolbar", {
     return _mTableToolbar["default"];
   }
 });
-
 var _mTableAction = _interopRequireDefault(require("./m-table-action"));
-
 var _mTableActions = _interopRequireDefault(require("./m-table-actions"));
-
 var _mTableBody = _interopRequireDefault(require("./m-table-body"));
-
 var _mTableBodyRow = _interopRequireDefault(require("./m-table-body-row"));
-
 var _mTableGroupbar = _interopRequireDefault(require("./m-table-groupbar"));
-
 var _mTableGroupRow = _interopRequireDefault(require("./m-table-group-row"));
-
 var _mTableCell = _interopRequireDefault(require("./m-table-cell"));
-
 var _mTableEditCell = _interopRequireDefault(require("./m-table-edit-cell"));
-
 var _mTableEditRow = _interopRequireDefault(require("./m-table-edit-row"));
-
 var _mTableEditField = _interopRequireDefault(require("./m-table-edit-field"));
-
 var _mTableFilterRow = _interopRequireDefault(require("./m-table-filter-row"));
-
 var _mTableHeader = _interopRequireDefault(require("./m-table-header"));
-
 var _mTablePagination = _interopRequireDefault(require("./m-table-pagination"));
-
 var _mTableSteppedPagination = _interopRequireDefault(require("./m-table-stepped-pagination"));
-
 var _mTableToolbar = _interopRequireDefault(require("./m-table-toolbar"));

--- a/dist/components/m-table-action.js
+++ b/dist/components/m-table-action.js
@@ -1,87 +1,60 @@
 "use strict";
 
-var _interopRequireWildcard = require("@babel/runtime/helpers/interopRequireWildcard");
-
 var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
-
+var _typeof = require("@babel/runtime/helpers/typeof");
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports["default"] = void 0;
-
 var _objectSpread2 = _interopRequireDefault(require("@babel/runtime/helpers/objectSpread"));
-
 var _classCallCheck2 = _interopRequireDefault(require("@babel/runtime/helpers/classCallCheck"));
-
 var _createClass2 = _interopRequireDefault(require("@babel/runtime/helpers/createClass"));
-
-var _inherits2 = _interopRequireDefault(require("@babel/runtime/helpers/inherits"));
-
 var _possibleConstructorReturn2 = _interopRequireDefault(require("@babel/runtime/helpers/possibleConstructorReturn"));
-
 var _getPrototypeOf2 = _interopRequireDefault(require("@babel/runtime/helpers/getPrototypeOf"));
-
+var _inherits2 = _interopRequireDefault(require("@babel/runtime/helpers/inherits"));
 var React = _interopRequireWildcard(require("react"));
-
 var _propTypes = _interopRequireDefault(require("prop-types"));
-
 var _Icon = _interopRequireDefault(require("@material-ui/core/Icon"));
-
 var _IconButton = _interopRequireDefault(require("@material-ui/core/IconButton"));
-
 var _Tooltip = _interopRequireDefault(require("@material-ui/core/Tooltip"));
-
-function _createSuper(Derived) { var hasNativeReflectConstruct = _isNativeReflectConstruct(); return function _createSuperInternal() { var Super = (0, _getPrototypeOf2["default"])(Derived), result; if (hasNativeReflectConstruct) { var NewTarget = (0, _getPrototypeOf2["default"])(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return (0, _possibleConstructorReturn2["default"])(this, result); }; }
-
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
-
+function _getRequireWildcardCache(e) { if ("function" != typeof WeakMap) return null; var r = new WeakMap(), t = new WeakMap(); return (_getRequireWildcardCache = function _getRequireWildcardCache(e) { return e ? t : r; })(e); }
+function _interopRequireWildcard(e, r) { if (!r && e && e.__esModule) return e; if (null === e || "object" != _typeof(e) && "function" != typeof e) return { "default": e }; var t = _getRequireWildcardCache(r); if (t && t.has(e)) return t.get(e); var n = { __proto__: null }, a = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var u in e) if ("default" !== u && {}.hasOwnProperty.call(e, u)) { var i = a ? Object.getOwnPropertyDescriptor(e, u) : null; i && (i.get || i.set) ? Object.defineProperty(n, u, i) : n[u] = e[u]; } return n["default"] = e, t && t.set(e, n), n; }
+function _callSuper(t, o, e) { return o = (0, _getPrototypeOf2["default"])(o), (0, _possibleConstructorReturn2["default"])(t, _isNativeReflectConstruct() ? Reflect.construct(o, e || [], (0, _getPrototypeOf2["default"])(t).constructor) : o.apply(t, e)); }
+function _isNativeReflectConstruct() { try { var t = !Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); } catch (t) {} return (_isNativeReflectConstruct = function _isNativeReflectConstruct() { return !!t; })(); } /* eslint-disable no-unused-vars */
 /* eslint-enable no-unused-vars */
 var MTableAction = /*#__PURE__*/function (_React$Component) {
-  (0, _inherits2["default"])(MTableAction, _React$Component);
-
-  var _super = _createSuper(MTableAction);
-
   function MTableAction() {
     (0, _classCallCheck2["default"])(this, MTableAction);
-    return _super.apply(this, arguments);
+    return _callSuper(this, MTableAction, arguments);
   }
-
-  (0, _createClass2["default"])(MTableAction, [{
+  (0, _inherits2["default"])(MTableAction, _React$Component);
+  return (0, _createClass2["default"])(MTableAction, [{
     key: "render",
     value: function render() {
       var _this = this;
-
       var action = this.props.action;
-
       if (typeof action === "function") {
         action = action(this.props.data);
-
         if (!action) {
           return null;
         }
       }
-
       if (action.action) {
         action = action.action(this.props.data);
-
         if (!action) {
           return null;
         }
       }
-
       if (action.hidden) {
         return null;
       }
-
       var disabled = action.disabled || this.props.disabled;
-
       var handleOnClick = function handleOnClick(event) {
         if (action.onClick) {
           action.onClick(event, _this.props.data);
           event.stopPropagation();
         }
       };
-
       var icon = typeof action.icon === "string" ? /*#__PURE__*/React.createElement(_Icon["default"], action.iconProps, action.icon) : typeof action.icon === "function" ? action.icon((0, _objectSpread2["default"])({}, action.iconProps, {
         disabled: disabled
       })) : /*#__PURE__*/React.createElement(action.icon, null);
@@ -91,7 +64,6 @@ var MTableAction = /*#__PURE__*/function (_React$Component) {
         disabled: disabled,
         onClick: handleOnClick
       }, icon);
-
       if (action.tooltip) {
         // fix for issue #1049
         // https://github.com/mbrn/material-table/issues/1049
@@ -105,9 +77,7 @@ var MTableAction = /*#__PURE__*/function (_React$Component) {
       }
     }
   }]);
-  return MTableAction;
 }(React.Component);
-
 MTableAction.defaultProps = {
   action: {},
   data: {}
@@ -118,5 +88,4 @@ MTableAction.propTypes = {
   disabled: _propTypes["default"].bool,
   size: _propTypes["default"].string
 };
-var _default = MTableAction;
-exports["default"] = _default;
+var _default = exports["default"] = MTableAction;

--- a/dist/components/m-table-actions.js
+++ b/dist/components/m-table-actions.js
@@ -1,48 +1,33 @@
 "use strict";
 
-var _interopRequireWildcard = require("@babel/runtime/helpers/interopRequireWildcard");
-
 var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
-
+var _typeof = require("@babel/runtime/helpers/typeof");
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports["default"] = void 0;
-
 var _classCallCheck2 = _interopRequireDefault(require("@babel/runtime/helpers/classCallCheck"));
-
 var _createClass2 = _interopRequireDefault(require("@babel/runtime/helpers/createClass"));
-
-var _inherits2 = _interopRequireDefault(require("@babel/runtime/helpers/inherits"));
-
 var _possibleConstructorReturn2 = _interopRequireDefault(require("@babel/runtime/helpers/possibleConstructorReturn"));
-
 var _getPrototypeOf2 = _interopRequireDefault(require("@babel/runtime/helpers/getPrototypeOf"));
-
+var _inherits2 = _interopRequireDefault(require("@babel/runtime/helpers/inherits"));
 var React = _interopRequireWildcard(require("react"));
-
 var _propTypes = _interopRequireDefault(require("prop-types"));
-
-function _createSuper(Derived) { var hasNativeReflectConstruct = _isNativeReflectConstruct(); return function _createSuperInternal() { var Super = (0, _getPrototypeOf2["default"])(Derived), result; if (hasNativeReflectConstruct) { var NewTarget = (0, _getPrototypeOf2["default"])(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return (0, _possibleConstructorReturn2["default"])(this, result); }; }
-
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
-
+function _getRequireWildcardCache(e) { if ("function" != typeof WeakMap) return null; var r = new WeakMap(), t = new WeakMap(); return (_getRequireWildcardCache = function _getRequireWildcardCache(e) { return e ? t : r; })(e); }
+function _interopRequireWildcard(e, r) { if (!r && e && e.__esModule) return e; if (null === e || "object" != _typeof(e) && "function" != typeof e) return { "default": e }; var t = _getRequireWildcardCache(r); if (t && t.has(e)) return t.get(e); var n = { __proto__: null }, a = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var u in e) if ("default" !== u && {}.hasOwnProperty.call(e, u)) { var i = a ? Object.getOwnPropertyDescriptor(e, u) : null; i && (i.get || i.set) ? Object.defineProperty(n, u, i) : n[u] = e[u]; } return n["default"] = e, t && t.set(e, n), n; }
+function _callSuper(t, o, e) { return o = (0, _getPrototypeOf2["default"])(o), (0, _possibleConstructorReturn2["default"])(t, _isNativeReflectConstruct() ? Reflect.construct(o, e || [], (0, _getPrototypeOf2["default"])(t).constructor) : o.apply(t, e)); }
+function _isNativeReflectConstruct() { try { var t = !Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); } catch (t) {} return (_isNativeReflectConstruct = function _isNativeReflectConstruct() { return !!t; })(); } /* eslint-disable no-unused-vars */
 /* eslint-enable no-unused-vars */
 var MTableActions = /*#__PURE__*/function (_React$Component) {
-  (0, _inherits2["default"])(MTableActions, _React$Component);
-
-  var _super = _createSuper(MTableActions);
-
   function MTableActions() {
     (0, _classCallCheck2["default"])(this, MTableActions);
-    return _super.apply(this, arguments);
+    return _callSuper(this, MTableActions, arguments);
   }
-
-  (0, _createClass2["default"])(MTableActions, [{
+  (0, _inherits2["default"])(MTableActions, _React$Component);
+  return (0, _createClass2["default"])(MTableActions, [{
     key: "render",
     value: function render() {
       var _this = this;
-
       if (this.props.actions) {
         return this.props.actions.map(function (action, index) {
           return /*#__PURE__*/React.createElement(_this.props.components.Action, {
@@ -54,13 +39,10 @@ var MTableActions = /*#__PURE__*/function (_React$Component) {
           });
         });
       }
-
       return null;
     }
   }]);
-  return MTableActions;
 }(React.Component);
-
 MTableActions.defaultProps = {
   actions: [],
   data: {}
@@ -72,5 +54,4 @@ MTableActions.propTypes = {
   disabled: _propTypes["default"].bool,
   size: _propTypes["default"].string
 };
-var _default = MTableActions;
-exports["default"] = _default;
+var _default = exports["default"] = MTableActions;

--- a/dist/components/m-table-body-row.js
+++ b/dist/components/m-table-body-row.js
@@ -1,95 +1,63 @@
 "use strict";
 
-var _interopRequireWildcard = require("@babel/runtime/helpers/interopRequireWildcard");
-
 var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
-
+var _typeof = require("@babel/runtime/helpers/typeof");
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports["default"] = void 0;
-
 var _toConsumableArray2 = _interopRequireDefault(require("@babel/runtime/helpers/toConsumableArray"));
-
 var _objectWithoutProperties2 = _interopRequireDefault(require("@babel/runtime/helpers/objectWithoutProperties"));
-
 var _extends2 = _interopRequireDefault(require("@babel/runtime/helpers/extends"));
-
 var _objectSpread2 = _interopRequireDefault(require("@babel/runtime/helpers/objectSpread"));
-
 var _classCallCheck2 = _interopRequireDefault(require("@babel/runtime/helpers/classCallCheck"));
-
 var _createClass2 = _interopRequireDefault(require("@babel/runtime/helpers/createClass"));
-
-var _assertThisInitialized2 = _interopRequireDefault(require("@babel/runtime/helpers/assertThisInitialized"));
-
-var _inherits2 = _interopRequireDefault(require("@babel/runtime/helpers/inherits"));
-
 var _possibleConstructorReturn2 = _interopRequireDefault(require("@babel/runtime/helpers/possibleConstructorReturn"));
-
 var _getPrototypeOf2 = _interopRequireDefault(require("@babel/runtime/helpers/getPrototypeOf"));
-
+var _inherits2 = _interopRequireDefault(require("@babel/runtime/helpers/inherits"));
 var _defineProperty2 = _interopRequireDefault(require("@babel/runtime/helpers/defineProperty"));
-
 var _Checkbox = _interopRequireDefault(require("@material-ui/core/Checkbox"));
-
 var _TableCell = _interopRequireDefault(require("@material-ui/core/TableCell"));
-
 var _TableRow = _interopRequireDefault(require("@material-ui/core/TableRow"));
-
 var _IconButton = _interopRequireDefault(require("@material-ui/core/IconButton"));
-
 var _Icon = _interopRequireDefault(require("@material-ui/core/Icon"));
-
 var _Tooltip = _interopRequireDefault(require("@material-ui/core/Tooltip"));
-
 var _propTypes = _interopRequireDefault(require("prop-types"));
-
 var React = _interopRequireWildcard(require("react"));
-
 var CommonValues = _interopRequireWildcard(require("../utils/common-values"));
-
-function _createSuper(Derived) { var hasNativeReflectConstruct = _isNativeReflectConstruct(); return function _createSuperInternal() { var Super = (0, _getPrototypeOf2["default"])(Derived), result; if (hasNativeReflectConstruct) { var NewTarget = (0, _getPrototypeOf2["default"])(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return (0, _possibleConstructorReturn2["default"])(this, result); }; }
-
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
-
+var _excluded = ["icons", "data", "columns", "components", "detailPanel", "getFieldValue", "isTreeData", "onRowClick", "onRowSelected", "onTreeExpandChanged", "onToggleDetailPanel", "onEditingCanceled", "onEditingApproved", "options", "hasAnyEditingRow", "treeDataMaxLevel", "localization", "actions", "errorState", "cellEditable", "onCellEditStarted", "onCellEditFinished", "scrollWidth"];
+function _getRequireWildcardCache(e) { if ("function" != typeof WeakMap) return null; var r = new WeakMap(), t = new WeakMap(); return (_getRequireWildcardCache = function _getRequireWildcardCache(e) { return e ? t : r; })(e); }
+function _interopRequireWildcard(e, r) { if (!r && e && e.__esModule) return e; if (null === e || "object" != _typeof(e) && "function" != typeof e) return { "default": e }; var t = _getRequireWildcardCache(r); if (t && t.has(e)) return t.get(e); var n = { __proto__: null }, a = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var u in e) if ("default" !== u && {}.hasOwnProperty.call(e, u)) { var i = a ? Object.getOwnPropertyDescriptor(e, u) : null; i && (i.get || i.set) ? Object.defineProperty(n, u, i) : n[u] = e[u]; } return n["default"] = e, t && t.set(e, n), n; }
+function _callSuper(t, o, e) { return o = (0, _getPrototypeOf2["default"])(o), (0, _possibleConstructorReturn2["default"])(t, _isNativeReflectConstruct() ? Reflect.construct(o, e || [], (0, _getPrototypeOf2["default"])(t).constructor) : o.apply(t, e)); }
+function _isNativeReflectConstruct() { try { var t = !Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); } catch (t) {} return (_isNativeReflectConstruct = function _isNativeReflectConstruct() { return !!t; })(); } /* eslint-disable no-unused-vars */
 /* eslint-enable no-unused-vars */
-var MTableBodyRow = /*#__PURE__*/function (_React$Component) {
-  (0, _inherits2["default"])(MTableBodyRow, _React$Component);
-
-  var _super = _createSuper(MTableBodyRow);
-
+var MTableBodyRow = exports["default"] = /*#__PURE__*/function (_React$Component) {
   function MTableBodyRow() {
     var _this;
-
     (0, _classCallCheck2["default"])(this, MTableBodyRow);
-
     for (var _len = arguments.length, args = new Array(_len), _key = 0; _key < _len; _key++) {
       args[_key] = arguments[_key];
     }
-
-    _this = _super.call.apply(_super, [this].concat(args));
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "rotateIconStyle", function (isOpen) {
+    _this = _callSuper(this, MTableBodyRow, [].concat(args));
+    (0, _defineProperty2["default"])(_this, "rotateIconStyle", function (isOpen) {
       return {
         transform: isOpen ? "rotate(90deg)" : "none"
       };
     });
     return _this;
   }
-
-  (0, _createClass2["default"])(MTableBodyRow, [{
+  (0, _inherits2["default"])(MTableBodyRow, _React$Component);
+  return (0, _createClass2["default"])(MTableBodyRow, [{
     key: "renderColumns",
     value: function renderColumns() {
       var _this2 = this;
-
       var size = CommonValues.elementSize(this.props);
       var mapArr = this.props.columns.filter(function (columnDef) {
-        return !columnDef.hidden && !(columnDef.tableData.groupOrder > -1 && !_this2.props.options.showGroupedColumnsWhileGrouped);
+        return !columnDef.hidden && (_this2.props.options.showGroupedColumnsWhileGrouped || columnDef.tableData.groupOrder === -1);
       }).sort(function (a, b) {
         return a.tableData.columnOrder - b.tableData.columnOrder;
       }).map(function (columnDef, index) {
         var value = _this2.props.getFieldValue(_this2.props.data, columnDef);
-
         if (_this2.props.data.tableData.editCellList && _this2.props.data.tableData.editCellList.find(function (c) {
           return c.tableData.id === columnDef.tableData.id;
         })) {
@@ -155,13 +123,10 @@ var MTableBodyRow = /*#__PURE__*/function (_React$Component) {
     key: "renderSelectionColumn",
     value: function renderSelectionColumn() {
       var _this3 = this;
-
       var checkboxProps = this.props.options.selectionProps || {};
-
       if (typeof checkboxProps === "function") {
         checkboxProps = checkboxProps(this.props.data);
       }
-
       var size = CommonValues.elementSize(this.props);
       var selectionWidth = CommonValues.selectionMaxWidth(this.props, this.props.treeDataMaxLevel);
       var styles = size === "medium" ? {
@@ -194,15 +159,12 @@ var MTableBodyRow = /*#__PURE__*/function (_React$Component) {
     key: "renderDetailPanelColumn",
     value: function renderDetailPanelColumn() {
       var _this4 = this;
-
       var size = CommonValues.elementSize(this.props);
-
       var CustomIcon = function CustomIcon(_ref) {
         var icon = _ref.icon,
-            iconProps = _ref.iconProps;
+          iconProps = _ref.iconProps;
         return typeof icon === "string" ? /*#__PURE__*/React.createElement(_Icon["default"], iconProps, icon) : React.createElement(icon, (0, _objectSpread2["default"])({}, iconProps));
       };
-
       if (typeof this.props.detailPanel == "function") {
         return /*#__PURE__*/React.createElement(_TableCell["default"], {
           size: size,
@@ -219,7 +181,6 @@ var MTableBodyRow = /*#__PURE__*/function (_React$Component) {
           }, this.rotateIconStyle(this.props.data.tableData.showDetailPanel)),
           onClick: function onClick(event) {
             _this4.props.onToggleDetailPanel(_this4.props.path, _this4.props.detailPanel);
-
             event.stopPropagation();
           }
         }, /*#__PURE__*/React.createElement(this.props.icons.DetailPanel, null)));
@@ -238,11 +199,9 @@ var MTableBodyRow = /*#__PURE__*/function (_React$Component) {
           if (typeof panel === "function") {
             panel = panel(_this4.props.data);
           }
-
           var isOpen = (_this4.props.data.tableData.showDetailPanel || "").toString() === panel.render.toString();
           var iconButton = /*#__PURE__*/React.createElement(_this4.props.icons.DetailPanel, null);
           var animation = true;
-
           if (isOpen) {
             if (panel.openIcon) {
               iconButton = /*#__PURE__*/React.createElement(CustomIcon, {
@@ -263,7 +222,6 @@ var MTableBodyRow = /*#__PURE__*/function (_React$Component) {
             });
             animation = false;
           }
-
           iconButton = /*#__PURE__*/React.createElement(_IconButton["default"], {
             size: size,
             key: "key-detail-panel-" + index,
@@ -273,18 +231,15 @@ var MTableBodyRow = /*#__PURE__*/function (_React$Component) {
             disabled: panel.disabled,
             onClick: function onClick(event) {
               _this4.props.onToggleDetailPanel(_this4.props.path, panel.render);
-
               event.stopPropagation();
             }
           }, iconButton);
-
           if (panel.tooltip) {
             iconButton = /*#__PURE__*/React.createElement(_Tooltip["default"], {
               key: "key-detail-panel-" + index,
               title: panel.tooltip
             }, iconButton);
           }
-
           return iconButton;
         })));
       }
@@ -293,9 +248,7 @@ var MTableBodyRow = /*#__PURE__*/function (_React$Component) {
     key: "renderTreeDataColumn",
     value: function renderTreeDataColumn() {
       var _this5 = this;
-
       var size = CommonValues.elementSize(this.props);
-
       if (this.props.data.tableData.childRows && this.props.data.tableData.childRows.length > 0) {
         return /*#__PURE__*/React.createElement(_TableCell["default"], {
           size: size,
@@ -312,7 +265,6 @@ var MTableBodyRow = /*#__PURE__*/function (_React$Component) {
           }, this.rotateIconStyle(this.props.data.tableData.isTreeExpanded)),
           onClick: function onClick(event) {
             _this5.props.onTreeExpandChanged(_this5.props.path, _this5.props.data);
-
             event.stopPropagation();
           }
         }, /*#__PURE__*/React.createElement(this.props.icons.DetailPanel, null)));
@@ -329,35 +281,28 @@ var MTableBodyRow = /*#__PURE__*/function (_React$Component) {
       var style = {
         transition: "all ease 300ms"
       };
-
       if (typeof this.props.options.rowStyle === "function") {
         style = (0, _objectSpread2["default"])({}, style, this.props.options.rowStyle(this.props.data, index, level, this.props.hasAnyEditingRow));
       } else if (this.props.options.rowStyle) {
         style = (0, _objectSpread2["default"])({}, style, this.props.options.rowStyle);
       }
-
       if (this.props.onRowClick) {
         style.cursor = "pointer";
       }
-
       if (this.props.hasAnyEditingRow) {
         style.opacity = style.opacity ? style.opacity : 0.2;
       }
-
       return style;
     }
   }, {
     key: "render",
     value: function render() {
       var _this6 = this;
-
       var size = CommonValues.elementSize(this.props);
       var renderColumns = this.renderColumns();
-
       if (this.props.options.selection) {
         renderColumns.splice(0, 0, this.renderSelectionColumn());
       }
-
       if (this.props.actions && this.props.actions.filter(function (a) {
         return a.position === "row" || typeof a === "function";
       }).length > 0) {
@@ -365,29 +310,26 @@ var MTableBodyRow = /*#__PURE__*/function (_React$Component) {
           renderColumns.push(this.renderActions());
         } else if (this.props.options.actionsColumnIndex >= 0) {
           var endPos = 0;
-
           if (this.props.options.selection) {
             endPos = 1;
           }
-
           renderColumns.splice(this.props.options.actionsColumnIndex + endPos, 0, this.renderActions());
         }
-      } // Then we add detail panel icon
+      }
 
-
+      // Then we add detail panel icon
       if (this.props.detailPanel) {
         if (this.props.options.detailPanelColumnAlignment === "right") {
           renderColumns.push(this.renderDetailPanelColumn());
         } else {
           renderColumns.splice(0, 0, this.renderDetailPanelColumn());
         }
-      } // Lastly we add tree data icon
+      }
 
-
+      // Lastly we add tree data icon
       if (this.props.isTreeData) {
         renderColumns.splice(0, 0, this.renderTreeDataColumn());
       }
-
       this.props.columns.filter(function (columnDef) {
         return columnDef.tableData.groupOrder > -1;
       }).forEach(function (columnDef) {
@@ -398,30 +340,30 @@ var MTableBodyRow = /*#__PURE__*/function (_React$Component) {
         }));
       });
       var _this$props = this.props,
-          icons = _this$props.icons,
-          data = _this$props.data,
-          columns = _this$props.columns,
-          components = _this$props.components,
-          detailPanel = _this$props.detailPanel,
-          getFieldValue = _this$props.getFieldValue,
-          isTreeData = _this$props.isTreeData,
-          onRowClick = _this$props.onRowClick,
-          onRowSelected = _this$props.onRowSelected,
-          onTreeExpandChanged = _this$props.onTreeExpandChanged,
-          onToggleDetailPanel = _this$props.onToggleDetailPanel,
-          onEditingCanceled = _this$props.onEditingCanceled,
-          onEditingApproved = _this$props.onEditingApproved,
-          options = _this$props.options,
-          hasAnyEditingRow = _this$props.hasAnyEditingRow,
-          treeDataMaxLevel = _this$props.treeDataMaxLevel,
-          localization = _this$props.localization,
-          actions = _this$props.actions,
-          errorState = _this$props.errorState,
-          cellEditable = _this$props.cellEditable,
-          onCellEditStarted = _this$props.onCellEditStarted,
-          onCellEditFinished = _this$props.onCellEditFinished,
-          scrollWidth = _this$props.scrollWidth,
-          rowProps = (0, _objectWithoutProperties2["default"])(_this$props, ["icons", "data", "columns", "components", "detailPanel", "getFieldValue", "isTreeData", "onRowClick", "onRowSelected", "onTreeExpandChanged", "onToggleDetailPanel", "onEditingCanceled", "onEditingApproved", "options", "hasAnyEditingRow", "treeDataMaxLevel", "localization", "actions", "errorState", "cellEditable", "onCellEditStarted", "onCellEditFinished", "scrollWidth"]);
+        icons = _this$props.icons,
+        data = _this$props.data,
+        columns = _this$props.columns,
+        components = _this$props.components,
+        detailPanel = _this$props.detailPanel,
+        getFieldValue = _this$props.getFieldValue,
+        isTreeData = _this$props.isTreeData,
+        onRowClick = _this$props.onRowClick,
+        onRowSelected = _this$props.onRowSelected,
+        onTreeExpandChanged = _this$props.onTreeExpandChanged,
+        onToggleDetailPanel = _this$props.onToggleDetailPanel,
+        onEditingCanceled = _this$props.onEditingCanceled,
+        onEditingApproved = _this$props.onEditingApproved,
+        options = _this$props.options,
+        hasAnyEditingRow = _this$props.hasAnyEditingRow,
+        treeDataMaxLevel = _this$props.treeDataMaxLevel,
+        localization = _this$props.localization,
+        actions = _this$props.actions,
+        errorState = _this$props.errorState,
+        cellEditable = _this$props.cellEditable,
+        onCellEditStarted = _this$props.onCellEditStarted,
+        onCellEditFinished = _this$props.onCellEditFinished,
+        scrollWidth = _this$props.scrollWidth,
+        rowProps = (0, _objectWithoutProperties2["default"])(_this$props, _excluded);
       return /*#__PURE__*/React.createElement(React.Fragment, null, /*#__PURE__*/React.createElement(_TableRow["default"], (0, _extends2["default"])({
         selected: hasAnyEditingRow
       }, rowProps, {
@@ -430,21 +372,18 @@ var MTableBodyRow = /*#__PURE__*/function (_React$Component) {
         onClick: function onClick(event) {
           onRowClick && onRowClick(event, _this6.props.data, function (panelIndex) {
             var panel = detailPanel;
-
             if (Array.isArray(panel)) {
               panel = panel[panelIndex || 0];
-
               if (typeof panel === "function") {
                 panel = panel(_this6.props.data);
               }
-
               panel = panel.render;
             }
-
             onToggleDetailPanel(_this6.props.path, panel);
           });
         }
-      }), renderColumns), this.props.data.tableData && this.props.data.tableData.showDetailPanel && /*#__PURE__*/React.createElement(_TableRow["default"] // selected={this.props.index % 2 === 0}
+      }), renderColumns), this.props.data.tableData && this.props.data.tableData.showDetailPanel && /*#__PURE__*/React.createElement(_TableRow["default"]
+      // selected={this.props.index % 2 === 0}
       , null, /*#__PURE__*/React.createElement(_TableCell["default"], {
         size: size,
         colSpan: renderColumns.length,
@@ -489,10 +428,7 @@ var MTableBodyRow = /*#__PURE__*/function (_React$Component) {
       }));
     }
   }]);
-  return MTableBodyRow;
 }(React.Component);
-
-exports["default"] = MTableBodyRow;
 MTableBodyRow.defaultProps = {
   actions: [],
   index: 0,

--- a/dist/components/m-table-body.js
+++ b/dist/components/m-table-body.js
@@ -1,80 +1,55 @@
 "use strict";
 
-var _interopRequireWildcard = require("@babel/runtime/helpers/interopRequireWildcard");
-
 var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
-
+var _typeof = require("@babel/runtime/helpers/typeof");
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports["default"] = void 0;
-
 var _toConsumableArray2 = _interopRequireDefault(require("@babel/runtime/helpers/toConsumableArray"));
-
 var _objectSpread2 = _interopRequireDefault(require("@babel/runtime/helpers/objectSpread"));
-
 var _classCallCheck2 = _interopRequireDefault(require("@babel/runtime/helpers/classCallCheck"));
-
 var _createClass2 = _interopRequireDefault(require("@babel/runtime/helpers/createClass"));
-
-var _inherits2 = _interopRequireDefault(require("@babel/runtime/helpers/inherits"));
-
 var _possibleConstructorReturn2 = _interopRequireDefault(require("@babel/runtime/helpers/possibleConstructorReturn"));
-
 var _getPrototypeOf2 = _interopRequireDefault(require("@babel/runtime/helpers/getPrototypeOf"));
-
+var _inherits2 = _interopRequireDefault(require("@babel/runtime/helpers/inherits"));
 var _TableBody = _interopRequireDefault(require("@material-ui/core/TableBody"));
-
 var _TableCell = _interopRequireDefault(require("@material-ui/core/TableCell"));
-
 var _TableRow = _interopRequireDefault(require("@material-ui/core/TableRow"));
-
 var _propTypes = _interopRequireDefault(require("prop-types"));
-
 var React = _interopRequireWildcard(require("react"));
-
-function _createSuper(Derived) { var hasNativeReflectConstruct = _isNativeReflectConstruct(); return function _createSuperInternal() { var Super = (0, _getPrototypeOf2["default"])(Derived), result; if (hasNativeReflectConstruct) { var NewTarget = (0, _getPrototypeOf2["default"])(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return (0, _possibleConstructorReturn2["default"])(this, result); }; }
-
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
-
+function _getRequireWildcardCache(e) { if ("function" != typeof WeakMap) return null; var r = new WeakMap(), t = new WeakMap(); return (_getRequireWildcardCache = function _getRequireWildcardCache(e) { return e ? t : r; })(e); }
+function _interopRequireWildcard(e, r) { if (!r && e && e.__esModule) return e; if (null === e || "object" != _typeof(e) && "function" != typeof e) return { "default": e }; var t = _getRequireWildcardCache(r); if (t && t.has(e)) return t.get(e); var n = { __proto__: null }, a = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var u in e) if ("default" !== u && {}.hasOwnProperty.call(e, u)) { var i = a ? Object.getOwnPropertyDescriptor(e, u) : null; i && (i.get || i.set) ? Object.defineProperty(n, u, i) : n[u] = e[u]; } return n["default"] = e, t && t.set(e, n), n; }
+function _callSuper(t, o, e) { return o = (0, _getPrototypeOf2["default"])(o), (0, _possibleConstructorReturn2["default"])(t, _isNativeReflectConstruct() ? Reflect.construct(o, e || [], (0, _getPrototypeOf2["default"])(t).constructor) : o.apply(t, e)); }
+function _isNativeReflectConstruct() { try { var t = !Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); } catch (t) {} return (_isNativeReflectConstruct = function _isNativeReflectConstruct() { return !!t; })(); } /* eslint-disable no-unused-vars */
 /* eslint-enable no-unused-vars */
 var MTableBody = /*#__PURE__*/function (_React$Component) {
-  (0, _inherits2["default"])(MTableBody, _React$Component);
-
-  var _super = _createSuper(MTableBody);
-
   function MTableBody() {
     (0, _classCallCheck2["default"])(this, MTableBody);
-    return _super.apply(this, arguments);
+    return _callSuper(this, MTableBody, arguments);
   }
-
-  (0, _createClass2["default"])(MTableBody, [{
+  (0, _inherits2["default"])(MTableBody, _React$Component);
+  return (0, _createClass2["default"])(MTableBody, [{
     key: "renderEmpty",
     value: function renderEmpty(emptyRowCount, renderData) {
       var rowHeight = this.props.options.padding === "default" ? 49 : 36;
       var localization = (0, _objectSpread2["default"])({}, MTableBody.defaultProps.localization, this.props.localization);
-
       if (this.props.options.showEmptyDataSourceMessage && renderData.length === 0) {
         var addColumn = 0;
-
         if (this.props.options.selection) {
           addColumn++;
         }
-
         if (this.props.actions && this.props.actions.filter(function (a) {
           return a.position === "row" || typeof a === "function";
         }).length > 0) {
           addColumn++;
         }
-
         if (this.props.hasDetailPanel) {
           addColumn++;
         }
-
         if (this.props.isTreeData) {
           addColumn++;
         }
-
         return /*#__PURE__*/React.createElement(_TableRow["default"], {
           style: {
             height: rowHeight * (this.props.options.paging && this.props.options.emptyRowsWhenPaging ? this.props.pageSize : 1)
@@ -111,7 +86,6 @@ var MTableBody = /*#__PURE__*/function (_React$Component) {
     key: "renderUngroupedRows",
     value: function renderUngroupedRows(renderData) {
       var _this = this;
-
       return renderData.map(function (data, index) {
         if (data.tableData.editing || _this.props.bulkEditOpen) {
           return /*#__PURE__*/React.createElement(_this.props.components.EditRow, {
@@ -175,7 +149,6 @@ var MTableBody = /*#__PURE__*/function (_React$Component) {
     key: "renderGroupedRows",
     value: function renderGroupedRows(groups, renderData) {
       var _this2 = this;
-
       return renderData.map(function (groupData, index) {
         return /*#__PURE__*/React.createElement(_this2.props.components.GroupRow, {
           actions: _this2.props.actions,
@@ -220,11 +193,9 @@ var MTableBody = /*#__PURE__*/function (_React$Component) {
         return col1.tableData.groupOrder - col2.tableData.groupOrder;
       });
       var emptyRowCount = 0;
-
       if (this.props.options.paging) {
         emptyRowCount = this.props.pageSize - renderData.length;
       }
-
       return /*#__PURE__*/React.createElement(_TableBody["default"], null, this.props.options.filtering && /*#__PURE__*/React.createElement(this.props.components.FilterRow, {
         options: this.props.options,
         columns: this.props.columns.filter(function (columnDef) {
@@ -290,9 +261,7 @@ var MTableBody = /*#__PURE__*/function (_React$Component) {
       }), this.renderEmpty(emptyRowCount, renderData));
     }
   }]);
-  return MTableBody;
 }(React.Component);
-
 MTableBody.defaultProps = {
   actions: [],
   currentPage: 0,
@@ -340,5 +309,4 @@ MTableBody.propTypes = {
   bulkEditOpen: _propTypes["default"].bool,
   onBulkEditRowChanged: _propTypes["default"].func
 };
-var _default = MTableBody;
-exports["default"] = _default;
+var _default = exports["default"] = MTableBody;

--- a/dist/components/m-table-cell.js
+++ b/dist/components/m-table-cell.js
@@ -1,75 +1,49 @@
 "use strict";
 
-var _interopRequireWildcard = require("@babel/runtime/helpers/interopRequireWildcard");
-
 var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
-
+var _typeof = require("@babel/runtime/helpers/typeof");
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports["default"] = void 0;
-
 var _extends2 = _interopRequireDefault(require("@babel/runtime/helpers/extends"));
-
 var _objectWithoutProperties2 = _interopRequireDefault(require("@babel/runtime/helpers/objectWithoutProperties"));
-
 var _objectSpread2 = _interopRequireDefault(require("@babel/runtime/helpers/objectSpread"));
-
 var _classCallCheck2 = _interopRequireDefault(require("@babel/runtime/helpers/classCallCheck"));
-
 var _createClass2 = _interopRequireDefault(require("@babel/runtime/helpers/createClass"));
-
-var _assertThisInitialized2 = _interopRequireDefault(require("@babel/runtime/helpers/assertThisInitialized"));
-
-var _inherits2 = _interopRequireDefault(require("@babel/runtime/helpers/inherits"));
-
 var _possibleConstructorReturn2 = _interopRequireDefault(require("@babel/runtime/helpers/possibleConstructorReturn"));
-
 var _getPrototypeOf2 = _interopRequireDefault(require("@babel/runtime/helpers/getPrototypeOf"));
-
+var _inherits2 = _interopRequireDefault(require("@babel/runtime/helpers/inherits"));
 var _defineProperty2 = _interopRequireDefault(require("@babel/runtime/helpers/defineProperty"));
-
 var React = _interopRequireWildcard(require("react"));
-
 var _TableCell = _interopRequireDefault(require("@material-ui/core/TableCell"));
-
 var _propTypes = _interopRequireDefault(require("prop-types"));
-
 var _parseISO = _interopRequireDefault(require("date-fns/parseISO"));
-
 var CommonValues = _interopRequireWildcard(require("../utils/common-values"));
-
-function _createSuper(Derived) { var hasNativeReflectConstruct = _isNativeReflectConstruct(); return function _createSuperInternal() { var Super = (0, _getPrototypeOf2["default"])(Derived), result; if (hasNativeReflectConstruct) { var NewTarget = (0, _getPrototypeOf2["default"])(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return (0, _possibleConstructorReturn2["default"])(this, result); }; }
-
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
-
+var _excluded = ["icons", "columnDef", "rowData", "errorState", "cellEditable", "onCellEditStarted", "scrollWidth"];
+function _getRequireWildcardCache(e) { if ("function" != typeof WeakMap) return null; var r = new WeakMap(), t = new WeakMap(); return (_getRequireWildcardCache = function _getRequireWildcardCache(e) { return e ? t : r; })(e); }
+function _interopRequireWildcard(e, r) { if (!r && e && e.__esModule) return e; if (null === e || "object" != _typeof(e) && "function" != typeof e) return { "default": e }; var t = _getRequireWildcardCache(r); if (t && t.has(e)) return t.get(e); var n = { __proto__: null }, a = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var u in e) if ("default" !== u && {}.hasOwnProperty.call(e, u)) { var i = a ? Object.getOwnPropertyDescriptor(e, u) : null; i && (i.get || i.set) ? Object.defineProperty(n, u, i) : n[u] = e[u]; } return n["default"] = e, t && t.set(e, n), n; }
+function _callSuper(t, o, e) { return o = (0, _getPrototypeOf2["default"])(o), (0, _possibleConstructorReturn2["default"])(t, _isNativeReflectConstruct() ? Reflect.construct(o, e || [], (0, _getPrototypeOf2["default"])(t).constructor) : o.apply(t, e)); }
+function _isNativeReflectConstruct() { try { var t = !Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); } catch (t) {} return (_isNativeReflectConstruct = function _isNativeReflectConstruct() { return !!t; })(); } /* eslint-disable no-unused-vars */
 /* eslint-enable no-unused-vars */
 
 /* eslint-disable no-useless-escape */
 var isoDateRegex = /^\d{4}-(0[1-9]|1[0-2])-([12]\d|0[1-9]|3[01])([T\s](([01]\d|2[0-3])\:[0-5]\d|24\:00)(\:[0-5]\d([\.,]\d+)?)?([zZ]|([\+-])([01]\d|2[0-3])\:?([0-5]\d)?)?)?$/;
 /* eslint-enable no-useless-escape */
-
-var MTableCell = /*#__PURE__*/function (_React$Component) {
-  (0, _inherits2["default"])(MTableCell, _React$Component);
-
-  var _super = _createSuper(MTableCell);
-
+var MTableCell = exports["default"] = /*#__PURE__*/function (_React$Component) {
   function MTableCell() {
     var _this;
-
     (0, _classCallCheck2["default"])(this, MTableCell);
-
     for (var _len = arguments.length, args = new Array(_len), _key = 0; _key < _len; _key++) {
       args[_key] = arguments[_key];
     }
-
-    _this = _super.call.apply(_super, [this].concat(args));
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "handleClickCell", function (e) {
+    _this = _callSuper(this, MTableCell, [].concat(args));
+    (0, _defineProperty2["default"])(_this, "handleClickCell", function (e) {
       if (_this.props.columnDef.disableClick) {
         e.stopPropagation();
       }
     });
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "getStyle", function () {
+    (0, _defineProperty2["default"])(_this, "getStyle", function () {
       var width = CommonValues.reducePercentsInCalc(_this.props.columnDef.tableData.width, _this.props.scrollWidth);
       var cellStyle = {
         color: "inherit",
@@ -81,31 +55,26 @@ var MTableCell = /*#__PURE__*/function (_React$Component) {
         fontFamily: "inherit",
         fontWeight: "inherit"
       };
-
       if (typeof _this.props.columnDef.cellStyle === "function") {
         cellStyle = (0, _objectSpread2["default"])({}, cellStyle, _this.props.columnDef.cellStyle(_this.props.value, _this.props.rowData));
       } else {
         cellStyle = (0, _objectSpread2["default"])({}, cellStyle, _this.props.columnDef.cellStyle);
       }
-
       if (_this.props.columnDef.disableClick) {
         cellStyle.cursor = "default";
       }
-
       return (0, _objectSpread2["default"])({}, _this.props.style, cellStyle);
     });
     return _this;
   }
-
-  (0, _createClass2["default"])(MTableCell, [{
+  (0, _inherits2["default"])(MTableCell, _React$Component);
+  return (0, _createClass2["default"])(MTableCell, [{
     key: "getRenderValue",
     value: function getRenderValue() {
       var dateLocale = this.props.columnDef.dateSetting && this.props.columnDef.dateSetting.locale ? this.props.columnDef.dateSetting.locale : undefined;
-
       if (this.props.columnDef.emptyValue !== undefined && (this.props.value === undefined || this.props.value === null)) {
         return this.getEmptyValue(this.props.columnDef.emptyValue);
       }
-
       if (this.props.columnDef.render) {
         if (this.props.rowData) {
           return this.props.columnDef.render(this.props.rowData, "row");
@@ -118,7 +87,6 @@ var MTableCell = /*#__PURE__*/function (_React$Component) {
           verticalAlign: "middle",
           width: 48
         };
-
         if (this.props.value) {
           return /*#__PURE__*/React.createElement(this.props.icons.Check, {
             style: style
@@ -158,7 +126,6 @@ var MTableCell = /*#__PURE__*/function (_React$Component) {
         // To avoid forwardref boolean children.
         return this.props.value.toString();
       }
-
       return this.props.value;
     }
   }, {
@@ -191,19 +158,17 @@ var MTableCell = /*#__PURE__*/function (_React$Component) {
     key: "render",
     value: function render() {
       var _this2 = this;
-
       var _this$props = this.props,
-          icons = _this$props.icons,
-          columnDef = _this$props.columnDef,
-          rowData = _this$props.rowData,
-          errorState = _this$props.errorState,
-          cellEditable = _this$props.cellEditable,
-          onCellEditStarted = _this$props.onCellEditStarted,
-          scrollWidth = _this$props.scrollWidth,
-          cellProps = (0, _objectWithoutProperties2["default"])(_this$props, ["icons", "columnDef", "rowData", "errorState", "cellEditable", "onCellEditStarted", "scrollWidth"]);
+        icons = _this$props.icons,
+        columnDef = _this$props.columnDef,
+        rowData = _this$props.rowData,
+        errorState = _this$props.errorState,
+        cellEditable = _this$props.cellEditable,
+        onCellEditStarted = _this$props.onCellEditStarted,
+        scrollWidth = _this$props.scrollWidth,
+        cellProps = (0, _objectWithoutProperties2["default"])(_this$props, _excluded);
       var cellAlignment = columnDef.align !== undefined ? columnDef.align : ["numeric", "currency"].indexOf(this.props.columnDef.type) !== -1 ? "right" : "left";
       var renderValue = this.getRenderValue();
-
       if (cellEditable) {
         renderValue = /*#__PURE__*/React.createElement("div", {
           style: {
@@ -217,7 +182,6 @@ var MTableCell = /*#__PURE__*/function (_React$Component) {
           }
         }, renderValue);
       }
-
       return /*#__PURE__*/React.createElement(_TableCell["default"], (0, _extends2["default"])({
         size: this.props.size
       }, cellProps, {
@@ -227,10 +191,7 @@ var MTableCell = /*#__PURE__*/function (_React$Component) {
       }), this.props.children, renderValue);
     }
   }]);
-  return MTableCell;
 }(React.Component);
-
-exports["default"] = MTableCell;
 MTableCell.defaultProps = {
   columnDef: {},
   value: undefined

--- a/dist/components/m-table-edit-cell.js
+++ b/dist/components/m-table-edit-cell.js
@@ -1,60 +1,36 @@
 "use strict";
 
-var _interopRequireWildcard = require("@babel/runtime/helpers/interopRequireWildcard");
-
 var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
-
+var _typeof = require("@babel/runtime/helpers/typeof");
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports["default"] = void 0;
-
 var _objectSpread2 = _interopRequireDefault(require("@babel/runtime/helpers/objectSpread"));
-
 var _classCallCheck2 = _interopRequireDefault(require("@babel/runtime/helpers/classCallCheck"));
-
 var _createClass2 = _interopRequireDefault(require("@babel/runtime/helpers/createClass"));
-
-var _assertThisInitialized2 = _interopRequireDefault(require("@babel/runtime/helpers/assertThisInitialized"));
-
-var _inherits2 = _interopRequireDefault(require("@babel/runtime/helpers/inherits"));
-
 var _possibleConstructorReturn2 = _interopRequireDefault(require("@babel/runtime/helpers/possibleConstructorReturn"));
-
 var _getPrototypeOf2 = _interopRequireDefault(require("@babel/runtime/helpers/getPrototypeOf"));
-
+var _inherits2 = _interopRequireDefault(require("@babel/runtime/helpers/inherits"));
 var _defineProperty2 = _interopRequireDefault(require("@babel/runtime/helpers/defineProperty"));
-
 var React = _interopRequireWildcard(require("react"));
-
 var _propTypes = _interopRequireDefault(require("prop-types"));
-
 var _TableCell = _interopRequireDefault(require("@material-ui/core/TableCell"));
-
 var _CircularProgress = _interopRequireDefault(require("@material-ui/core/CircularProgress"));
-
 var _colorManipulator = require("@material-ui/core/styles/colorManipulator");
-
 var _withTheme = _interopRequireDefault(require("@material-ui/core/styles/withTheme"));
-
 var _ = require("..");
-
-function _createSuper(Derived) { var hasNativeReflectConstruct = _isNativeReflectConstruct(); return function _createSuperInternal() { var Super = (0, _getPrototypeOf2["default"])(Derived), result; if (hasNativeReflectConstruct) { var NewTarget = (0, _getPrototypeOf2["default"])(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return (0, _possibleConstructorReturn2["default"])(this, result); }; }
-
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
-
+function _getRequireWildcardCache(e) { if ("function" != typeof WeakMap) return null; var r = new WeakMap(), t = new WeakMap(); return (_getRequireWildcardCache = function _getRequireWildcardCache(e) { return e ? t : r; })(e); }
+function _interopRequireWildcard(e, r) { if (!r && e && e.__esModule) return e; if (null === e || "object" != _typeof(e) && "function" != typeof e) return { "default": e }; var t = _getRequireWildcardCache(r); if (t && t.has(e)) return t.get(e); var n = { __proto__: null }, a = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var u in e) if ("default" !== u && {}.hasOwnProperty.call(e, u)) { var i = a ? Object.getOwnPropertyDescriptor(e, u) : null; i && (i.get || i.set) ? Object.defineProperty(n, u, i) : n[u] = e[u]; } return n["default"] = e, t && t.set(e, n), n; }
+function _callSuper(t, o, e) { return o = (0, _getPrototypeOf2["default"])(o), (0, _possibleConstructorReturn2["default"])(t, _isNativeReflectConstruct() ? Reflect.construct(o, e || [], (0, _getPrototypeOf2["default"])(t).constructor) : o.apply(t, e)); }
+function _isNativeReflectConstruct() { try { var t = !Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); } catch (t) {} return (_isNativeReflectConstruct = function _isNativeReflectConstruct() { return !!t; })(); } /* eslint-disable no-unused-vars */
 /* eslint-enable no-unused-vars */
 var MTableEditCell = /*#__PURE__*/function (_React$Component) {
-  (0, _inherits2["default"])(MTableEditCell, _React$Component);
-
-  var _super = _createSuper(MTableEditCell);
-
   function MTableEditCell(props) {
     var _this;
-
     (0, _classCallCheck2["default"])(this, MTableEditCell);
-    _this = _super.call(this, props);
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "getStyle", function () {
+    _this = _callSuper(this, MTableEditCell, [props]);
+    (0, _defineProperty2["default"])(_this, "getStyle", function () {
       var cellStyle = {
         boxShadow: "2px 0px 15px rgba(125,147,178,.25)",
         color: "inherit",
@@ -65,41 +41,40 @@ var MTableEditCell = /*#__PURE__*/function (_React$Component) {
         fontWeight: "inherit",
         padding: "0 16px"
       };
-
       if (typeof _this.props.columnDef.cellStyle === "function") {
         cellStyle = (0, _objectSpread2["default"])({}, cellStyle, _this.props.columnDef.cellStyle(_this.state.value, _this.props.rowData));
       } else {
         cellStyle = (0, _objectSpread2["default"])({}, cellStyle, _this.props.columnDef.cellStyle);
       }
-
       if (typeof _this.props.cellEditable.cellStyle === "function") {
         cellStyle = (0, _objectSpread2["default"])({}, cellStyle, _this.props.cellEditable.cellStyle(_this.state.value, _this.props.rowData, _this.props.columnDef));
       } else {
         cellStyle = (0, _objectSpread2["default"])({}, cellStyle, _this.props.cellEditable.cellStyle);
       }
-
       return cellStyle;
     });
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "handleKeyDown", function (e) {
+    (0, _defineProperty2["default"])(_this, "handleKeyDown", function (e) {
       if (e.keyCode === 13) {
         _this.onApprove();
       } else if (e.keyCode === 27) {
         _this.onCancel();
       }
     });
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "onApprove", function () {
+    (0, _defineProperty2["default"])(_this, "onApprove", function () {
       _this.setState({
         isLoading: true
       }, function () {
-        _this.props.cellEditable.onCellEditApproved(_this.state.value, // newValue
-        _this.props.rowData[_this.props.columnDef.field], // oldValue
-        _this.props.rowData, // rowData with old value
+        _this.props.cellEditable.onCellEditApproved(_this.state.value,
+        // newValue
+        _this.props.rowData[_this.props.columnDef.field],
+        // oldValue
+        _this.props.rowData,
+        // rowData with old value
         _this.props.columnDef // columnDef
         ).then(function () {
           _this.setState({
             isLoading: false
           });
-
           _this.props.onCellEditFinished(_this.props.rowData, _this.props.columnDef);
         })["catch"](function (error) {
           _this.setState({
@@ -108,7 +83,7 @@ var MTableEditCell = /*#__PURE__*/function (_React$Component) {
         });
       });
     });
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "onCancel", function () {
+    (0, _defineProperty2["default"])(_this, "onCancel", function () {
       _this.props.onCellEditFinished(_this.props.rowData, _this.props.columnDef);
     });
     _this.state = {
@@ -117,8 +92,8 @@ var MTableEditCell = /*#__PURE__*/function (_React$Component) {
     };
     return _this;
   }
-
-  (0, _createClass2["default"])(MTableEditCell, [{
+  (0, _inherits2["default"])(MTableEditCell, _React$Component);
+  return (0, _createClass2["default"])(MTableEditCell, [{
     key: "renderActions",
     value: function renderActions() {
       if (this.state.isLoading) {
@@ -132,7 +107,6 @@ var MTableEditCell = /*#__PURE__*/function (_React$Component) {
           size: 20
         }));
       }
-
       var actions = [{
         icon: this.props.icons.Check,
         tooltip: this.props.localization.saveTooltip,
@@ -154,7 +128,6 @@ var MTableEditCell = /*#__PURE__*/function (_React$Component) {
     key: "render",
     value: function render() {
       var _this2 = this;
-
       return /*#__PURE__*/React.createElement(_TableCell["default"], {
         size: this.props.size,
         style: this.getStyle(),
@@ -183,9 +156,7 @@ var MTableEditCell = /*#__PURE__*/function (_React$Component) {
       })), this.renderActions()));
     }
   }]);
-  return MTableEditCell;
 }(React.Component);
-
 MTableEditCell.defaultProps = {
   columnDef: {}
 };
@@ -200,7 +171,4 @@ MTableEditCell.propTypes = {
   rowData: _propTypes["default"].object.isRequired,
   size: _propTypes["default"].string
 };
-
-var _default = (0, _withTheme["default"])(MTableEditCell);
-
-exports["default"] = _default;
+var _default = exports["default"] = (0, _withTheme["default"])(MTableEditCell);

--- a/dist/components/m-table-edit-field.js
+++ b/dist/components/m-table-edit-field.js
@@ -1,89 +1,64 @@
 "use strict";
 
-var _interopRequireWildcard = require("@babel/runtime/helpers/interopRequireWildcard");
-
 var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
-
+var _typeof = require("@babel/runtime/helpers/typeof");
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports["default"] = void 0;
-
 var _extends2 = _interopRequireDefault(require("@babel/runtime/helpers/extends"));
-
 var _objectWithoutProperties2 = _interopRequireDefault(require("@babel/runtime/helpers/objectWithoutProperties"));
-
 var _classCallCheck2 = _interopRequireDefault(require("@babel/runtime/helpers/classCallCheck"));
-
 var _createClass2 = _interopRequireDefault(require("@babel/runtime/helpers/createClass"));
-
-var _inherits2 = _interopRequireDefault(require("@babel/runtime/helpers/inherits"));
-
 var _possibleConstructorReturn2 = _interopRequireDefault(require("@babel/runtime/helpers/possibleConstructorReturn"));
-
 var _getPrototypeOf2 = _interopRequireDefault(require("@babel/runtime/helpers/getPrototypeOf"));
-
+var _inherits2 = _interopRequireDefault(require("@babel/runtime/helpers/inherits"));
 var React = _interopRequireWildcard(require("react"));
-
 var _TextField = _interopRequireDefault(require("@material-ui/core/TextField"));
-
 var _Checkbox = _interopRequireDefault(require("@material-ui/core/Checkbox"));
-
 var _Select = _interopRequireDefault(require("@material-ui/core/Select"));
-
 var _MenuItem = _interopRequireDefault(require("@material-ui/core/MenuItem"));
-
 var _FormControl = _interopRequireDefault(require("@material-ui/core/FormControl"));
-
 var _FormHelperText = _interopRequireDefault(require("@material-ui/core/FormHelperText"));
-
 var _FormGroup = _interopRequireDefault(require("@material-ui/core/FormGroup"));
-
 var _FormControlLabel = _interopRequireDefault(require("@material-ui/core/FormControlLabel"));
-
 var _dateFns = _interopRequireDefault(require("@date-io/date-fns"));
-
 var _pickers = require("@material-ui/pickers");
-
 var _propTypes = _interopRequireDefault(require("prop-types"));
-
-function _createSuper(Derived) { var hasNativeReflectConstruct = _isNativeReflectConstruct(); return function _createSuperInternal() { var Super = (0, _getPrototypeOf2["default"])(Derived), result; if (hasNativeReflectConstruct) { var NewTarget = (0, _getPrototypeOf2["default"])(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return (0, _possibleConstructorReturn2["default"])(this, result); }; }
-
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
-
+var _excluded = ["columnDef", "rowData", "onRowDataChange", "errorState", "onBulkEditRowChanged", "scrollWidth"],
+  _excluded2 = ["helperText", "error"],
+  _excluded3 = ["helperText", "error"];
+function _getRequireWildcardCache(e) { if ("function" != typeof WeakMap) return null; var r = new WeakMap(), t = new WeakMap(); return (_getRequireWildcardCache = function _getRequireWildcardCache(e) { return e ? t : r; })(e); }
+function _interopRequireWildcard(e, r) { if (!r && e && e.__esModule) return e; if (null === e || "object" != _typeof(e) && "function" != typeof e) return { "default": e }; var t = _getRequireWildcardCache(r); if (t && t.has(e)) return t.get(e); var n = { __proto__: null }, a = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var u in e) if ("default" !== u && {}.hasOwnProperty.call(e, u)) { var i = a ? Object.getOwnPropertyDescriptor(e, u) : null; i && (i.get || i.set) ? Object.defineProperty(n, u, i) : n[u] = e[u]; } return n["default"] = e, t && t.set(e, n), n; }
+function _callSuper(t, o, e) { return o = (0, _getPrototypeOf2["default"])(o), (0, _possibleConstructorReturn2["default"])(t, _isNativeReflectConstruct() ? Reflect.construct(o, e || [], (0, _getPrototypeOf2["default"])(t).constructor) : o.apply(t, e)); }
+function _isNativeReflectConstruct() { try { var t = !Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); } catch (t) {} return (_isNativeReflectConstruct = function _isNativeReflectConstruct() { return !!t; })(); }
 var MTableEditField = /*#__PURE__*/function (_React$Component) {
-  (0, _inherits2["default"])(MTableEditField, _React$Component);
-
-  var _super = _createSuper(MTableEditField);
-
   function MTableEditField() {
     (0, _classCallCheck2["default"])(this, MTableEditField);
-    return _super.apply(this, arguments);
+    return _callSuper(this, MTableEditField, arguments);
   }
-
-  (0, _createClass2["default"])(MTableEditField, [{
+  (0, _inherits2["default"])(MTableEditField, _React$Component);
+  return (0, _createClass2["default"])(MTableEditField, [{
     key: "getProps",
     value: function getProps() {
       var _this$props = this.props,
-          columnDef = _this$props.columnDef,
-          rowData = _this$props.rowData,
-          onRowDataChange = _this$props.onRowDataChange,
-          errorState = _this$props.errorState,
-          onBulkEditRowChanged = _this$props.onBulkEditRowChanged,
-          scrollWidth = _this$props.scrollWidth,
-          props = (0, _objectWithoutProperties2["default"])(_this$props, ["columnDef", "rowData", "onRowDataChange", "errorState", "onBulkEditRowChanged", "scrollWidth"]);
+        columnDef = _this$props.columnDef,
+        rowData = _this$props.rowData,
+        onRowDataChange = _this$props.onRowDataChange,
+        errorState = _this$props.errorState,
+        onBulkEditRowChanged = _this$props.onBulkEditRowChanged,
+        scrollWidth = _this$props.scrollWidth,
+        props = (0, _objectWithoutProperties2["default"])(_this$props, _excluded);
       return props;
     }
   }, {
     key: "renderLookupField",
     value: function renderLookupField() {
       var _this = this;
-
       var _this$getProps = this.getProps(),
-          helperText = _this$getProps.helperText,
-          error = _this$getProps.error,
-          props = (0, _objectWithoutProperties2["default"])(_this$getProps, ["helperText", "error"]);
-
+        helperText = _this$getProps.helperText,
+        error = _this$getProps.error,
+        props = (0, _objectWithoutProperties2["default"])(_this$getProps, _excluded2);
       return /*#__PURE__*/React.createElement(_FormControl["default"], {
         error: Boolean(error)
       }, /*#__PURE__*/React.createElement(_Select["default"], (0, _extends2["default"])({}, props, {
@@ -108,12 +83,10 @@ var MTableEditField = /*#__PURE__*/function (_React$Component) {
     key: "renderBooleanField",
     value: function renderBooleanField() {
       var _this2 = this;
-
       var _this$getProps2 = this.getProps(),
-          helperText = _this$getProps2.helperText,
-          error = _this$getProps2.error,
-          props = (0, _objectWithoutProperties2["default"])(_this$getProps2, ["helperText", "error"]);
-
+        helperText = _this$getProps2.helperText,
+        error = _this$getProps2.error,
+        props = (0, _objectWithoutProperties2["default"])(_this$getProps2, _excluded3);
       return /*#__PURE__*/React.createElement(_FormControl["default"], {
         error: Boolean(error),
         component: "fieldset"
@@ -204,7 +177,6 @@ var MTableEditField = /*#__PURE__*/function (_React$Component) {
     key: "renderTextField",
     value: function renderTextField() {
       var _this3 = this;
-
       return /*#__PURE__*/React.createElement(_TextField["default"], (0, _extends2["default"])({}, this.getProps(), {
         fullWidth: true,
         style: this.props.columnDef.type === "numeric" ? {
@@ -230,7 +202,6 @@ var MTableEditField = /*#__PURE__*/function (_React$Component) {
     key: "renderCurrencyField",
     value: function renderCurrencyField() {
       var _this4 = this;
-
       return /*#__PURE__*/React.createElement(_TextField["default"], (0, _extends2["default"])({}, this.getProps(), {
         placeholder: this.props.columnDef.editPlaceholder || this.props.columnDef.title,
         style: {
@@ -240,11 +211,9 @@ var MTableEditField = /*#__PURE__*/function (_React$Component) {
         value: this.props.value === undefined ? "" : this.props.value,
         onChange: function onChange(event) {
           var value = event.target.valueAsNumber;
-
           if (!value && value !== 0) {
             value = undefined;
           }
-
           return _this4.props.onChange(value);
         },
         inputProps: {
@@ -262,7 +231,6 @@ var MTableEditField = /*#__PURE__*/function (_React$Component) {
     key: "render",
     value: function render() {
       var component = "ok";
-
       if (this.props.columnDef.lookup) {
         component = this.renderLookupField();
       } else if (this.props.columnDef.type === "boolean") {
@@ -278,18 +246,14 @@ var MTableEditField = /*#__PURE__*/function (_React$Component) {
       } else {
         component = this.renderTextField();
       }
-
       return component;
     }
   }]);
-  return MTableEditField;
 }(React.Component);
-
 MTableEditField.propTypes = {
   value: _propTypes["default"].any,
   onChange: _propTypes["default"].func.isRequired,
   columnDef: _propTypes["default"].object.isRequired,
   locale: _propTypes["default"].object
 };
-var _default = MTableEditField;
-exports["default"] = _default;
+var _default = exports["default"] = MTableEditField;

--- a/dist/components/m-table-edit-row.js
+++ b/dist/components/m-table-edit-row.js
@@ -1,72 +1,46 @@
 "use strict";
 
-var _interopRequireWildcard = require("@babel/runtime/helpers/interopRequireWildcard");
-
 var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
-
+var _typeof3 = require("@babel/runtime/helpers/typeof");
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports["default"] = void 0;
-
 var _extends2 = _interopRequireDefault(require("@babel/runtime/helpers/extends"));
-
 var _typeof2 = _interopRequireDefault(require("@babel/runtime/helpers/typeof"));
-
 var _objectWithoutProperties2 = _interopRequireDefault(require("@babel/runtime/helpers/objectWithoutProperties"));
-
 var _objectSpread2 = _interopRequireDefault(require("@babel/runtime/helpers/objectSpread"));
-
 var _classCallCheck2 = _interopRequireDefault(require("@babel/runtime/helpers/classCallCheck"));
-
 var _createClass2 = _interopRequireDefault(require("@babel/runtime/helpers/createClass"));
-
-var _assertThisInitialized2 = _interopRequireDefault(require("@babel/runtime/helpers/assertThisInitialized"));
-
-var _inherits2 = _interopRequireDefault(require("@babel/runtime/helpers/inherits"));
-
 var _possibleConstructorReturn2 = _interopRequireDefault(require("@babel/runtime/helpers/possibleConstructorReturn"));
-
 var _getPrototypeOf2 = _interopRequireDefault(require("@babel/runtime/helpers/getPrototypeOf"));
-
+var _inherits2 = _interopRequireDefault(require("@babel/runtime/helpers/inherits"));
 var _defineProperty2 = _interopRequireDefault(require("@babel/runtime/helpers/defineProperty"));
-
 var _TableCell = _interopRequireDefault(require("@material-ui/core/TableCell"));
-
 var _TableRow = _interopRequireDefault(require("@material-ui/core/TableRow"));
-
 var _Typography = _interopRequireDefault(require("@material-ui/core/Typography"));
-
 var _propTypes = _interopRequireDefault(require("prop-types"));
-
 var React = _interopRequireWildcard(require("react"));
-
 var _utils = require("../utils");
-
 var CommonValues = _interopRequireWildcard(require("../utils/common-values"));
-
-function _createSuper(Derived) { var hasNativeReflectConstruct = _isNativeReflectConstruct(); return function _createSuperInternal() { var Super = (0, _getPrototypeOf2["default"])(Derived), result; if (hasNativeReflectConstruct) { var NewTarget = (0, _getPrototypeOf2["default"])(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return (0, _possibleConstructorReturn2["default"])(this, result); }; }
-
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
-
+var _excluded = ["editComponent"],
+  _excluded2 = ["detailPanel", "isTreeData", "onRowClick", "onRowSelected", "onTreeExpandChanged", "onToggleDetailPanel", "onEditingApproved", "onEditingCanceled", "getFieldValue", "components", "icons", "columns", "localization", "options", "actions", "errorState", "onBulkEditRowChanged", "scrollWidth"];
+function _getRequireWildcardCache(e) { if ("function" != typeof WeakMap) return null; var r = new WeakMap(), t = new WeakMap(); return (_getRequireWildcardCache = function _getRequireWildcardCache(e) { return e ? t : r; })(e); }
+function _interopRequireWildcard(e, r) { if (!r && e && e.__esModule) return e; if (null === e || "object" != _typeof3(e) && "function" != typeof e) return { "default": e }; var t = _getRequireWildcardCache(r); if (t && t.has(e)) return t.get(e); var n = { __proto__: null }, a = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var u in e) if ("default" !== u && {}.hasOwnProperty.call(e, u)) { var i = a ? Object.getOwnPropertyDescriptor(e, u) : null; i && (i.get || i.set) ? Object.defineProperty(n, u, i) : n[u] = e[u]; } return n["default"] = e, t && t.set(e, n), n; }
+function _callSuper(t, o, e) { return o = (0, _getPrototypeOf2["default"])(o), (0, _possibleConstructorReturn2["default"])(t, _isNativeReflectConstruct() ? Reflect.construct(o, e || [], (0, _getPrototypeOf2["default"])(t).constructor) : o.apply(t, e)); }
+function _isNativeReflectConstruct() { try { var t = !Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); } catch (t) {} return (_isNativeReflectConstruct = function _isNativeReflectConstruct() { return !!t; })(); } /* eslint-disable no-unused-vars */
 /* eslint-enable no-unused-vars */
-var MTableEditRow = /*#__PURE__*/function (_React$Component) {
-  (0, _inherits2["default"])(MTableEditRow, _React$Component);
-
-  var _super = _createSuper(MTableEditRow);
-
+var MTableEditRow = exports["default"] = /*#__PURE__*/function (_React$Component) {
   function MTableEditRow(props) {
     var _this;
-
     (0, _classCallCheck2["default"])(this, MTableEditRow);
-    _this = _super.call(this, props);
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "handleSave", function () {
+    _this = _callSuper(this, MTableEditRow, [props]);
+    (0, _defineProperty2["default"])(_this, "handleSave", function () {
       var newData = _this.state.data;
       delete newData.tableData;
-
       _this.props.onEditingApproved(_this.props.mode, _this.state.data, _this.props.data);
     });
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "handleKeyDown", function (e) {
+    (0, _defineProperty2["default"])(_this, "handleKeyDown", function (e) {
       if (e.keyCode === 13 && e.target.type !== "textarea") {
         _this.handleSave();
       } else if (e.keyCode === 13 && e.target.type === "textarea" && e.shiftKey) {
@@ -80,8 +54,8 @@ var MTableEditRow = /*#__PURE__*/function (_React$Component) {
     };
     return _this;
   }
-
-  (0, _createClass2["default"])(MTableEditRow, [{
+  (0, _inherits2["default"])(MTableEditRow, _React$Component);
+  return (0, _createClass2["default"])(MTableEditRow, [{
     key: "createRowData",
     value: function createRowData() {
       return this.props.columns.filter(function (column) {
@@ -95,64 +69,49 @@ var MTableEditRow = /*#__PURE__*/function (_React$Component) {
     key: "renderColumns",
     value: function renderColumns() {
       var _this2 = this;
-
       var size = CommonValues.elementSize(this.props);
       var mapArr = this.props.columns.filter(function (columnDef) {
-        return !columnDef.hidden && !(columnDef.tableData.groupOrder > -1 && !_this2.props.options.showGroupedColumnsWhileGrouped);
+        return !columnDef.hidden && (_this2.props.options.showGroupedColumnsWhileGrouped || columnDef.tableData.groupOrder === -1);
       }).sort(function (a, b) {
         return a.tableData.columnOrder - b.tableData.columnOrder;
       }).map(function (columnDef, index) {
         var value = typeof _this2.state.data[columnDef.field] !== "undefined" ? _this2.state.data[columnDef.field] : (0, _utils.byString)(_this2.state.data, columnDef.field);
-
         var getCellStyle = function getCellStyle(columnDef, value) {
           var cellStyle = {
             color: "inherit"
           };
-
           if (typeof columnDef.cellStyle === "function") {
             cellStyle = (0, _objectSpread2["default"])({}, cellStyle, columnDef.cellStyle(value, _this2.props.data));
           } else {
             cellStyle = (0, _objectSpread2["default"])({}, cellStyle, columnDef.cellStyle);
           }
-
           if (columnDef.disableClick) {
             cellStyle.cursor = "default";
           }
-
           return (0, _objectSpread2["default"])({}, cellStyle);
         };
-
         var style = {};
-
         if (index === 0) {
           style.paddingLeft = 24 + _this2.props.level * 20;
         }
-
         var allowEditing = false;
-
         if (columnDef.editable === undefined) {
           allowEditing = true;
         }
-
         if (columnDef.editable === "always") {
           allowEditing = true;
         }
-
         if (columnDef.editable === "onAdd" && _this2.props.mode === "add") {
           allowEditing = true;
         }
-
         if (columnDef.editable === "onUpdate" && _this2.props.mode === "update") {
           allowEditing = true;
         }
-
         if (typeof columnDef.editable === "function") {
           allowEditing = columnDef.editable(columnDef, _this2.props.data);
         }
-
         if (!columnDef.field || !allowEditing) {
           var readonlyValue = _this2.props.getFieldValue(_this2.state.data, columnDef);
-
           return /*#__PURE__*/React.createElement(_this2.props.components.Cell, {
             size: size,
             icons: _this2.props.icons,
@@ -164,28 +123,24 @@ var MTableEditRow = /*#__PURE__*/function (_React$Component) {
           });
         } else {
           var editComponent = columnDef.editComponent,
-              cellProps = (0, _objectWithoutProperties2["default"])(columnDef, ["editComponent"]);
+            cellProps = (0, _objectWithoutProperties2["default"])(columnDef, _excluded);
           var EditComponent = editComponent || _this2.props.components.EditField;
           var error = {
             isValid: true,
             helperText: ""
           };
-
           if (columnDef.validate) {
             var validateResponse = columnDef.validate(_this2.state.data);
-
             switch ((0, _typeof2["default"])(validateResponse)) {
               case "object":
                 error = (0, _objectSpread2["default"])({}, validateResponse);
                 break;
-
               case "boolean":
                 error = {
                   isValid: validateResponse,
                   helperText: ""
                 };
                 break;
-
               case "string":
                 error = {
                   isValid: false,
@@ -194,7 +149,6 @@ var MTableEditRow = /*#__PURE__*/function (_React$Component) {
                 break;
             }
           }
-
           return /*#__PURE__*/React.createElement(_TableCell["default"], {
             size: size,
             key: columnDef.tableData.id,
@@ -210,8 +164,8 @@ var MTableEditRow = /*#__PURE__*/function (_React$Component) {
             rowData: _this2.state.data,
             onChange: function onChange(value) {
               var data = (0, _objectSpread2["default"])({}, _this2.state.data);
-              (0, _utils.setByString)(data, columnDef.field, value); // data[columnDef.field] = value;
-
+              (0, _utils.setByString)(data, columnDef.field, value);
+              // data[columnDef.field] = value;
               _this2.setState({
                 data: data
               }, function () {
@@ -238,27 +192,22 @@ var MTableEditRow = /*#__PURE__*/function (_React$Component) {
     key: "renderActions",
     value: function renderActions() {
       var _this3 = this;
-
       if (this.props.mode === "bulk") {
         return /*#__PURE__*/React.createElement(_TableCell["default"], {
           padding: "none",
           key: "key-actions-column"
         });
       }
-
       var size = CommonValues.elementSize(this.props);
       var localization = (0, _objectSpread2["default"])({}, MTableEditRow.defaultProps.localization, this.props.localization);
       var isValid = this.props.columns.every(function (column) {
         if (column.validate) {
           var response = column.validate(_this3.state.data);
-
           switch ((0, _typeof2["default"])(response)) {
             case "object":
               return response.isValid;
-
             case "string":
               return response.length === 0;
-
             case "boolean":
               return response;
           }
@@ -310,16 +259,14 @@ var MTableEditRow = /*#__PURE__*/function (_React$Component) {
     key: "render",
     value: function render() {
       var _this4 = this;
-
       var size = CommonValues.elementSize(this.props);
       var localization = (0, _objectSpread2["default"])({}, MTableEditRow.defaultProps.localization, this.props.localization);
       var columns;
-
       if (this.props.mode === "add" || this.props.mode === "update" || this.props.mode === "bulk") {
         columns = this.renderColumns();
       } else {
         var colSpan = this.props.columns.filter(function (columnDef) {
-          return !columnDef.hidden && !(columnDef.tableData.groupOrder > -1 && !_this4.props.options.showGroupedColumnsWhileGrouped);
+          return !columnDef.hidden && (_this4.props.options.showGroupedColumnsWhileGrouped || columnDef.tableData.groupOrder === -1);
         }).length;
         columns = [/*#__PURE__*/React.createElement(_TableCell["default"], {
           size: size,
@@ -330,42 +277,35 @@ var MTableEditRow = /*#__PURE__*/function (_React$Component) {
           variant: "h6"
         }, localization.deleteText))];
       }
-
       if (this.props.options.selection) {
         columns.splice(0, 0, /*#__PURE__*/React.createElement(_TableCell["default"], {
           padding: "none",
           key: "key-selection-cell"
         }));
       }
-
       if (this.props.isTreeData) {
         columns.splice(0, 0, /*#__PURE__*/React.createElement(_TableCell["default"], {
           padding: "none",
           key: "key-tree-data-cell"
         }));
       }
-
       if (this.props.options.actionsColumnIndex === -1) {
         columns.push(this.renderActions());
       } else if (this.props.options.actionsColumnIndex >= 0) {
         var endPos = 0;
-
         if (this.props.options.selection) {
           endPos = 1;
         }
-
         if (this.props.isTreeData) {
           endPos = 1;
-
           if (this.props.options.selection) {
             columns.splice(1, 1);
           }
         }
-
         columns.splice(this.props.options.actionsColumnIndex + endPos, 0, this.renderActions());
-      } // Lastly we add detail panel icon
+      }
 
-
+      // Lastly we add detail panel icon
       if (this.props.detailPanel) {
         var aligment = this.props.options.detailPanelColumnAlignment;
         var index = aligment === "left" ? 0 : columns.length;
@@ -374,7 +314,6 @@ var MTableEditRow = /*#__PURE__*/function (_React$Component) {
           key: "key-detail-panel-cell"
         }));
       }
-
       this.props.columns.filter(function (columnDef) {
         return columnDef.tableData.groupOrder > -1;
       }).forEach(function (columnDef) {
@@ -384,25 +323,25 @@ var MTableEditRow = /*#__PURE__*/function (_React$Component) {
         }));
       });
       var _this$props = this.props,
-          detailPanel = _this$props.detailPanel,
-          isTreeData = _this$props.isTreeData,
-          onRowClick = _this$props.onRowClick,
-          onRowSelected = _this$props.onRowSelected,
-          onTreeExpandChanged = _this$props.onTreeExpandChanged,
-          onToggleDetailPanel = _this$props.onToggleDetailPanel,
-          onEditingApproved = _this$props.onEditingApproved,
-          onEditingCanceled = _this$props.onEditingCanceled,
-          getFieldValue = _this$props.getFieldValue,
-          components = _this$props.components,
-          icons = _this$props.icons,
-          columnsProp = _this$props.columns,
-          localizationProp = _this$props.localization,
-          options = _this$props.options,
-          actions = _this$props.actions,
-          errorState = _this$props.errorState,
-          onBulkEditRowChanged = _this$props.onBulkEditRowChanged,
-          scrollWidth = _this$props.scrollWidth,
-          rowProps = (0, _objectWithoutProperties2["default"])(_this$props, ["detailPanel", "isTreeData", "onRowClick", "onRowSelected", "onTreeExpandChanged", "onToggleDetailPanel", "onEditingApproved", "onEditingCanceled", "getFieldValue", "components", "icons", "columns", "localization", "options", "actions", "errorState", "onBulkEditRowChanged", "scrollWidth"]);
+        detailPanel = _this$props.detailPanel,
+        isTreeData = _this$props.isTreeData,
+        onRowClick = _this$props.onRowClick,
+        onRowSelected = _this$props.onRowSelected,
+        onTreeExpandChanged = _this$props.onTreeExpandChanged,
+        onToggleDetailPanel = _this$props.onToggleDetailPanel,
+        onEditingApproved = _this$props.onEditingApproved,
+        onEditingCanceled = _this$props.onEditingCanceled,
+        getFieldValue = _this$props.getFieldValue,
+        components = _this$props.components,
+        icons = _this$props.icons,
+        columnsProp = _this$props.columns,
+        localizationProp = _this$props.localization,
+        options = _this$props.options,
+        actions = _this$props.actions,
+        errorState = _this$props.errorState,
+        onBulkEditRowChanged = _this$props.onBulkEditRowChanged,
+        scrollWidth = _this$props.scrollWidth,
+        rowProps = (0, _objectWithoutProperties2["default"])(_this$props, _excluded2);
       return /*#__PURE__*/React.createElement(React.Fragment, null, /*#__PURE__*/React.createElement(_TableRow["default"], (0, _extends2["default"])({
         onKeyDown: this.handleKeyDown
       }, rowProps, {
@@ -410,10 +349,7 @@ var MTableEditRow = /*#__PURE__*/function (_React$Component) {
       }), columns));
     }
   }]);
-  return MTableEditRow;
 }(React.Component);
-
-exports["default"] = MTableEditRow;
 MTableEditRow.defaultProps = {
   actions: [],
   index: 0,

--- a/dist/components/m-table-filter-row.js
+++ b/dist/components/m-table-filter-row.js
@@ -1,70 +1,40 @@
 "use strict";
 
-var _interopRequireWildcard = require("@babel/runtime/helpers/interopRequireWildcard");
-
 var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
-
+var _typeof = require("@babel/runtime/helpers/typeof");
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports["default"] = void 0;
-
 var _slicedToArray2 = _interopRequireDefault(require("@babel/runtime/helpers/slicedToArray"));
-
 var _objectSpread2 = _interopRequireDefault(require("@babel/runtime/helpers/objectSpread"));
-
 var _classCallCheck2 = _interopRequireDefault(require("@babel/runtime/helpers/classCallCheck"));
-
 var _createClass2 = _interopRequireDefault(require("@babel/runtime/helpers/createClass"));
-
-var _assertThisInitialized2 = _interopRequireDefault(require("@babel/runtime/helpers/assertThisInitialized"));
-
-var _inherits2 = _interopRequireDefault(require("@babel/runtime/helpers/inherits"));
-
 var _possibleConstructorReturn2 = _interopRequireDefault(require("@babel/runtime/helpers/possibleConstructorReturn"));
-
 var _getPrototypeOf2 = _interopRequireDefault(require("@babel/runtime/helpers/getPrototypeOf"));
-
+var _inherits2 = _interopRequireDefault(require("@babel/runtime/helpers/inherits"));
 var _defineProperty2 = _interopRequireDefault(require("@babel/runtime/helpers/defineProperty"));
-
 var React = _interopRequireWildcard(require("react"));
-
 var _propTypes = _interopRequireDefault(require("prop-types"));
-
 var _TableCell = _interopRequireDefault(require("@material-ui/core/TableCell"));
-
 var _TableRow = _interopRequireDefault(require("@material-ui/core/TableRow"));
-
 var _TextField = _interopRequireDefault(require("@material-ui/core/TextField"));
-
 var _FormControl = _interopRequireDefault(require("@material-ui/core/FormControl"));
-
 var _Select = _interopRequireDefault(require("@material-ui/core/Select"));
-
 var _Input = _interopRequireDefault(require("@material-ui/core/Input"));
-
 var _InputLabel = _interopRequireDefault(require("@material-ui/core/InputLabel"));
-
 var _MenuItem = _interopRequireDefault(require("@material-ui/core/MenuItem"));
-
 var _Checkbox = _interopRequireDefault(require("@material-ui/core/Checkbox"));
-
 var _ListItemText = _interopRequireDefault(require("@material-ui/core/ListItemText"));
-
 var _InputAdornment = _interopRequireDefault(require("@material-ui/core/InputAdornment"));
-
 var _Icon = _interopRequireDefault(require("@material-ui/core/Icon"));
-
 var _Tooltip = _interopRequireDefault(require("@material-ui/core/Tooltip"));
-
 var _dateFns = _interopRequireDefault(require("@date-io/date-fns"));
-
 var _pickers = require("@material-ui/pickers");
-
-function _createSuper(Derived) { var hasNativeReflectConstruct = _isNativeReflectConstruct(); return function _createSuperInternal() { var Super = (0, _getPrototypeOf2["default"])(Derived), result; if (hasNativeReflectConstruct) { var NewTarget = (0, _getPrototypeOf2["default"])(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return (0, _possibleConstructorReturn2["default"])(this, result); }; }
-
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
-
+function _getRequireWildcardCache(e) { if ("function" != typeof WeakMap) return null; var r = new WeakMap(), t = new WeakMap(); return (_getRequireWildcardCache = function _getRequireWildcardCache(e) { return e ? t : r; })(e); }
+function _interopRequireWildcard(e, r) { if (!r && e && e.__esModule) return e; if (null === e || "object" != _typeof(e) && "function" != typeof e) return { "default": e }; var t = _getRequireWildcardCache(r); if (t && t.has(e)) return t.get(e); var n = { __proto__: null }, a = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var u in e) if ("default" !== u && {}.hasOwnProperty.call(e, u)) { var i = a ? Object.getOwnPropertyDescriptor(e, u) : null; i && (i.get || i.set) ? Object.defineProperty(n, u, i) : n[u] = e[u]; } return n["default"] = e, t && t.set(e, n), n; }
+function _callSuper(t, o, e) { return o = (0, _getPrototypeOf2["default"])(o), (0, _possibleConstructorReturn2["default"])(t, _isNativeReflectConstruct() ? Reflect.construct(o, e || [], (0, _getPrototypeOf2["default"])(t).constructor) : o.apply(t, e)); }
+function _isNativeReflectConstruct() { try { var t = !Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); } catch (t) {} return (_isNativeReflectConstruct = function _isNativeReflectConstruct() { return !!t; })(); } /* eslint-disable no-unused-vars */
 var ITEM_HEIGHT = 48;
 var ITEM_PADDING_TOP = 8;
 var MenuProps = {
@@ -75,36 +45,26 @@ var MenuProps = {
     }
   }
 };
-
 var MTableFilterRow = /*#__PURE__*/function (_React$Component) {
-  (0, _inherits2["default"])(MTableFilterRow, _React$Component);
-
-  var _super = _createSuper(MTableFilterRow);
-
   function MTableFilterRow() {
     var _this;
-
     (0, _classCallCheck2["default"])(this, MTableFilterRow);
-
     for (var _len = arguments.length, args = new Array(_len), _key = 0; _key < _len; _key++) {
       args[_key] = arguments[_key];
     }
-
-    _this = _super.call.apply(_super, [this].concat(args));
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "getLocalizationData", function () {
+    _this = _callSuper(this, MTableFilterRow, [].concat(args));
+    (0, _defineProperty2["default"])(_this, "getLocalizationData", function () {
       return (0, _objectSpread2["default"])({}, MTableFilterRow.defaultProps.localization, _this.props.localization);
     });
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "getLocalizedFilterPlaceHolder", function (columnDef) {
+    (0, _defineProperty2["default"])(_this, "getLocalizedFilterPlaceHolder", function (columnDef) {
       return columnDef.filterPlaceholder || _this.getLocalizationData().filterPlaceHolder || "";
     });
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "LookupFilter", function (_ref) {
+    (0, _defineProperty2["default"])(_this, "LookupFilter", function (_ref) {
       var columnDef = _ref.columnDef;
-
       var _React$useState = React.useState(columnDef.tableData.filterValue || []),
-          _React$useState2 = (0, _slicedToArray2["default"])(_React$useState, 2),
-          selectedFilter = _React$useState2[0],
-          setSelectedFilter = _React$useState2[1];
-
+        _React$useState2 = (0, _slicedToArray2["default"])(_React$useState, 2),
+        selectedFilter = _React$useState2[0],
+        setSelectedFilter = _React$useState2[1];
       React.useEffect(function () {
         setSelectedFilter(columnDef.tableData.filterValue || []);
       }, [columnDef.tableData.filterValue]);
@@ -150,32 +110,29 @@ var MTableFilterRow = /*#__PURE__*/function (_React$Component) {
         }));
       })));
     });
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "renderFilterComponent", function (columnDef) {
+    (0, _defineProperty2["default"])(_this, "renderFilterComponent", function (columnDef) {
       return React.createElement(columnDef.filterComponent, {
         columnDef: columnDef,
         onFilterChanged: _this.props.onFilterChanged
       });
     });
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "renderBooleanFilter", function (columnDef) {
+    (0, _defineProperty2["default"])(_this, "renderBooleanFilter", function (columnDef) {
       return /*#__PURE__*/React.createElement(_Checkbox["default"], {
         indeterminate: columnDef.tableData.filterValue === undefined,
         checked: columnDef.tableData.filterValue === "checked",
         onChange: function onChange() {
           var val;
-
           if (columnDef.tableData.filterValue === undefined) {
             val = "checked";
           } else if (columnDef.tableData.filterValue === "checked") {
             val = "unchecked";
           }
-
           _this.props.onFilterChanged(columnDef.tableData.id, val);
         }
       });
     });
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "renderDefaultFilter", function (columnDef) {
+    (0, _defineProperty2["default"])(_this, "renderDefaultFilter", function (columnDef) {
       var localization = _this.getLocalizationData();
-
       var FilterIcon = _this.props.icons.Filter;
       return /*#__PURE__*/React.createElement(_TextField["default"], {
         style: columnDef.type === "numeric" ? {
@@ -199,11 +156,10 @@ var MTableFilterRow = /*#__PURE__*/function (_React$Component) {
         }
       });
     });
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "renderDateTypeFilter", function (columnDef) {
+    (0, _defineProperty2["default"])(_this, "renderDateTypeFilter", function (columnDef) {
       var onDateInputChange = function onDateInputChange(date) {
         return _this.props.onFilterChanged(columnDef.tableData.id, date);
       };
-
       var pickerProps = {
         value: columnDef.tableData.filterValue || null,
         onChange: onDateInputChange,
@@ -211,7 +167,6 @@ var MTableFilterRow = /*#__PURE__*/function (_React$Component) {
         clearable: true
       };
       var dateInputElement = null;
-
       if (columnDef.type === "date") {
         dateInputElement = /*#__PURE__*/React.createElement(_pickers.DatePicker, pickerProps);
       } else if (columnDef.type === "datetime") {
@@ -219,7 +174,6 @@ var MTableFilterRow = /*#__PURE__*/function (_React$Component) {
       } else if (columnDef.type === "time") {
         dateInputElement = /*#__PURE__*/React.createElement(_pickers.TimePicker, pickerProps);
       }
-
       return /*#__PURE__*/React.createElement(_pickers.MuiPickersUtilsProvider, {
         utils: _dateFns["default"],
         locale: _this.props.localization.dateTimePickerLocalization
@@ -227,14 +181,13 @@ var MTableFilterRow = /*#__PURE__*/function (_React$Component) {
     });
     return _this;
   }
-
-  (0, _createClass2["default"])(MTableFilterRow, [{
+  (0, _inherits2["default"])(MTableFilterRow, _React$Component);
+  return (0, _createClass2["default"])(MTableFilterRow, [{
     key: "getComponentForColumn",
     value: function getComponentForColumn(columnDef) {
       if (columnDef.filtering === false) {
         return null;
       }
-
       if (columnDef.field || columnDef.customFilterAndSearch) {
         if (columnDef.filterComponent) {
           return this.renderFilterComponent(columnDef);
@@ -255,9 +208,8 @@ var MTableFilterRow = /*#__PURE__*/function (_React$Component) {
     key: "render",
     value: function render() {
       var _this2 = this;
-
       var columns = this.props.columns.filter(function (columnDef) {
-        return !columnDef.hidden && !(columnDef.tableData.groupOrder > -1 && !_this2.props.options.showGroupedColumnsWhileGrouped);
+        return !columnDef.hidden && (_this2.props.options.showGroupedColumnsWhileGrouped || columnDef.tableData.groupOrder === -1);
       }).sort(function (a, b) {
         return a.tableData.columnOrder - b.tableData.columnOrder;
       }).map(function (columnDef) {
@@ -266,14 +218,12 @@ var MTableFilterRow = /*#__PURE__*/function (_React$Component) {
           style: (0, _objectSpread2["default"])({}, _this2.props.filterCellStyle, columnDef.filterCellStyle)
         }, _this2.getComponentForColumn(columnDef));
       });
-
       if (this.props.selection) {
         columns.splice(0, 0, /*#__PURE__*/React.createElement(_TableCell["default"], {
           padding: "none",
           key: "key-selection-column"
         }));
       }
-
       if (this.props.hasActions) {
         if (this.props.actionsColumnIndex === -1) {
           columns.push( /*#__PURE__*/React.createElement(_TableCell["default"], {
@@ -281,17 +231,14 @@ var MTableFilterRow = /*#__PURE__*/function (_React$Component) {
           }));
         } else {
           var endPos = 0;
-
           if (this.props.selection) {
             endPos = 1;
           }
-
           columns.splice(this.props.actionsColumnIndex + endPos, 0, /*#__PURE__*/React.createElement(_TableCell["default"], {
             key: "key-action-column"
           }));
         }
       }
-
       if (this.props.hasDetailPanel) {
         var alignment = this.props.detailPanelColumnAlignment;
         var index = alignment === "left" ? 0 : columns.length;
@@ -300,14 +247,12 @@ var MTableFilterRow = /*#__PURE__*/function (_React$Component) {
           key: "key-detail-panel-column"
         }));
       }
-
       if (this.props.isTreeData > 0) {
         columns.splice(0, 0, /*#__PURE__*/React.createElement(_TableCell["default"], {
           padding: "none",
           key: "key-tree-data-filter"
         }));
       }
-
       this.props.columns.filter(function (columnDef) {
         return columnDef.tableData.groupOrder > -1;
       }).forEach(function (columnDef) {
@@ -323,9 +268,7 @@ var MTableFilterRow = /*#__PURE__*/function (_React$Component) {
       }, columns);
     }
   }]);
-  return MTableFilterRow;
 }(React.Component);
-
 MTableFilterRow.defaultProps = {
   options: {},
   columns: [],
@@ -351,5 +294,4 @@ MTableFilterRow.propTypes = {
   localization: _propTypes["default"].object,
   hideFilterIcons: _propTypes["default"].bool
 };
-var _default = MTableFilterRow;
-exports["default"] = _default;
+var _default = exports["default"] = MTableFilterRow;

--- a/dist/components/m-table-group-row.js
+++ b/dist/components/m-table-group-row.js
@@ -1,75 +1,49 @@
 "use strict";
 
-var _interopRequireWildcard = require("@babel/runtime/helpers/interopRequireWildcard");
-
 var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
-
+var _typeof = require("@babel/runtime/helpers/typeof");
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports["default"] = void 0;
-
 var _objectSpread2 = _interopRequireDefault(require("@babel/runtime/helpers/objectSpread"));
-
 var _toConsumableArray2 = _interopRequireDefault(require("@babel/runtime/helpers/toConsumableArray"));
-
 var _classCallCheck2 = _interopRequireDefault(require("@babel/runtime/helpers/classCallCheck"));
-
 var _createClass2 = _interopRequireDefault(require("@babel/runtime/helpers/createClass"));
-
-var _assertThisInitialized2 = _interopRequireDefault(require("@babel/runtime/helpers/assertThisInitialized"));
-
-var _inherits2 = _interopRequireDefault(require("@babel/runtime/helpers/inherits"));
-
 var _possibleConstructorReturn2 = _interopRequireDefault(require("@babel/runtime/helpers/possibleConstructorReturn"));
-
 var _getPrototypeOf2 = _interopRequireDefault(require("@babel/runtime/helpers/getPrototypeOf"));
-
+var _inherits2 = _interopRequireDefault(require("@babel/runtime/helpers/inherits"));
 var _defineProperty2 = _interopRequireDefault(require("@babel/runtime/helpers/defineProperty"));
-
 var _TableCell = _interopRequireDefault(require("@material-ui/core/TableCell"));
-
 var _TableRow = _interopRequireDefault(require("@material-ui/core/TableRow"));
-
 var _IconButton = _interopRequireDefault(require("@material-ui/core/IconButton"));
-
 var _propTypes = _interopRequireDefault(require("prop-types"));
-
 var React = _interopRequireWildcard(require("react"));
-
-function _createSuper(Derived) { var hasNativeReflectConstruct = _isNativeReflectConstruct(); return function _createSuperInternal() { var Super = (0, _getPrototypeOf2["default"])(Derived), result; if (hasNativeReflectConstruct) { var NewTarget = (0, _getPrototypeOf2["default"])(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return (0, _possibleConstructorReturn2["default"])(this, result); }; }
-
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
-
+function _getRequireWildcardCache(e) { if ("function" != typeof WeakMap) return null; var r = new WeakMap(), t = new WeakMap(); return (_getRequireWildcardCache = function _getRequireWildcardCache(e) { return e ? t : r; })(e); }
+function _interopRequireWildcard(e, r) { if (!r && e && e.__esModule) return e; if (null === e || "object" != _typeof(e) && "function" != typeof e) return { "default": e }; var t = _getRequireWildcardCache(r); if (t && t.has(e)) return t.get(e); var n = { __proto__: null }, a = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var u in e) if ("default" !== u && {}.hasOwnProperty.call(e, u)) { var i = a ? Object.getOwnPropertyDescriptor(e, u) : null; i && (i.get || i.set) ? Object.defineProperty(n, u, i) : n[u] = e[u]; } return n["default"] = e, t && t.set(e, n), n; }
+function _callSuper(t, o, e) { return o = (0, _getPrototypeOf2["default"])(o), (0, _possibleConstructorReturn2["default"])(t, _isNativeReflectConstruct() ? Reflect.construct(o, e || [], (0, _getPrototypeOf2["default"])(t).constructor) : o.apply(t, e)); }
+function _isNativeReflectConstruct() { try { var t = !Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); } catch (t) {} return (_isNativeReflectConstruct = function _isNativeReflectConstruct() { return !!t; })(); } /* eslint-disable no-unused-vars */
 /* eslint-enable no-unused-vars */
-var MTableGroupRow = /*#__PURE__*/function (_React$Component) {
-  (0, _inherits2["default"])(MTableGroupRow, _React$Component);
-
-  var _super = _createSuper(MTableGroupRow);
-
+var MTableGroupRow = exports["default"] = /*#__PURE__*/function (_React$Component) {
   function MTableGroupRow() {
     var _this;
-
     (0, _classCallCheck2["default"])(this, MTableGroupRow);
-
     for (var _len = arguments.length, args = new Array(_len), _key = 0; _key < _len; _key++) {
       args[_key] = arguments[_key];
     }
-
-    _this = _super.call.apply(_super, [this].concat(args));
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "rotateIconStyle", function (isOpen) {
+    _this = _callSuper(this, MTableGroupRow, [].concat(args));
+    (0, _defineProperty2["default"])(_this, "rotateIconStyle", function (isOpen) {
       return {
         transform: isOpen ? "rotate(90deg)" : "none"
       };
     });
     return _this;
   }
-
-  (0, _createClass2["default"])(MTableGroupRow, [{
+  (0, _inherits2["default"])(MTableGroupRow, _React$Component);
+  return (0, _createClass2["default"])(MTableGroupRow, [{
     key: "render",
     value: function render() {
       var _this2 = this;
-
       var colSpan = this.props.columns.filter(function (columnDef) {
         return !columnDef.hidden;
       }).length;
@@ -78,7 +52,6 @@ var MTableGroupRow = /*#__PURE__*/function (_React$Component) {
       this.props.actions && this.props.actions.length > 0 && colSpan++;
       var column = this.props.groups[this.props.level];
       var detail;
-
       if (this.props.groupData.isExpanded) {
         if (this.props.groups.length > this.props.level + 1) {
           // Is there another group
@@ -161,32 +134,25 @@ var MTableGroupRow = /*#__PURE__*/function (_React$Component) {
           });
         }
       }
-
       var freeCells = [];
-
       for (var i = 0; i < this.props.level; i++) {
         freeCells.push( /*#__PURE__*/React.createElement(_TableCell["default"], {
           padding: "checkbox",
           key: i
         }));
       }
-
       var value = this.props.groupData.value;
-
       if (column.getGroupTitle) {
         value = column.getGroupTitle(this.props.groupData);
       } else if (column.lookup) {
         value = column.lookup[value];
       }
-
       var title = column.title;
-
       if (typeof this.props.options.groupTitle === "function") {
         title = this.props.options.groupTitle(this.props.groupData);
       } else if (typeof title !== "string") {
         title = React.cloneElement(title);
       }
-
       var separator = this.props.options.groupRowSeparator || ": ";
       return /*#__PURE__*/React.createElement(React.Fragment, null, /*#__PURE__*/React.createElement(_TableRow["default"], null, freeCells, /*#__PURE__*/React.createElement(this.props.components.Cell, {
         colSpan: colSpan,
@@ -204,10 +170,7 @@ var MTableGroupRow = /*#__PURE__*/function (_React$Component) {
       }, /*#__PURE__*/React.createElement(this.props.icons.DetailPanel, null)), /*#__PURE__*/React.createElement("b", null, title, separator))), detail);
     }
   }]);
-  return MTableGroupRow;
 }(React.Component);
-
-exports["default"] = MTableGroupRow;
 MTableGroupRow.defaultProps = {
   columns: [],
   groups: [],

--- a/dist/components/m-table-groupbar.js
+++ b/dist/components/m-table-groupbar.js
@@ -1,60 +1,36 @@
 "use strict";
 
-var _interopRequireWildcard = require("@babel/runtime/helpers/interopRequireWildcard");
-
 var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
-
+var _typeof = require("@babel/runtime/helpers/typeof");
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports["default"] = void 0;
-
 var _extends2 = _interopRequireDefault(require("@babel/runtime/helpers/extends"));
-
 var _objectSpread2 = _interopRequireDefault(require("@babel/runtime/helpers/objectSpread"));
-
 var _classCallCheck2 = _interopRequireDefault(require("@babel/runtime/helpers/classCallCheck"));
-
 var _createClass2 = _interopRequireDefault(require("@babel/runtime/helpers/createClass"));
-
-var _assertThisInitialized2 = _interopRequireDefault(require("@babel/runtime/helpers/assertThisInitialized"));
-
-var _inherits2 = _interopRequireDefault(require("@babel/runtime/helpers/inherits"));
-
 var _possibleConstructorReturn2 = _interopRequireDefault(require("@babel/runtime/helpers/possibleConstructorReturn"));
-
 var _getPrototypeOf2 = _interopRequireDefault(require("@babel/runtime/helpers/getPrototypeOf"));
-
+var _inherits2 = _interopRequireDefault(require("@babel/runtime/helpers/inherits"));
 var _defineProperty2 = _interopRequireDefault(require("@babel/runtime/helpers/defineProperty"));
-
 var _Toolbar = _interopRequireDefault(require("@material-ui/core/Toolbar"));
-
 var _Chip = _interopRequireDefault(require("@material-ui/core/Chip"));
-
 var _Typography = _interopRequireDefault(require("@material-ui/core/Typography"));
-
 var _propTypes = _interopRequireDefault(require("prop-types"));
-
 var React = _interopRequireWildcard(require("react"));
-
 var _reactBeautifulDnd = require("react-beautiful-dnd");
-
-function _createSuper(Derived) { var hasNativeReflectConstruct = _isNativeReflectConstruct(); return function _createSuperInternal() { var Super = (0, _getPrototypeOf2["default"])(Derived), result; if (hasNativeReflectConstruct) { var NewTarget = (0, _getPrototypeOf2["default"])(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return (0, _possibleConstructorReturn2["default"])(this, result); }; }
-
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
-
+function _getRequireWildcardCache(e) { if ("function" != typeof WeakMap) return null; var r = new WeakMap(), t = new WeakMap(); return (_getRequireWildcardCache = function _getRequireWildcardCache(e) { return e ? t : r; })(e); }
+function _interopRequireWildcard(e, r) { if (!r && e && e.__esModule) return e; if (null === e || "object" != _typeof(e) && "function" != typeof e) return { "default": e }; var t = _getRequireWildcardCache(r); if (t && t.has(e)) return t.get(e); var n = { __proto__: null }, a = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var u in e) if ("default" !== u && {}.hasOwnProperty.call(e, u)) { var i = a ? Object.getOwnPropertyDescriptor(e, u) : null; i && (i.get || i.set) ? Object.defineProperty(n, u, i) : n[u] = e[u]; } return n["default"] = e, t && t.set(e, n), n; }
+function _callSuper(t, o, e) { return o = (0, _getPrototypeOf2["default"])(o), (0, _possibleConstructorReturn2["default"])(t, _isNativeReflectConstruct() ? Reflect.construct(o, e || [], (0, _getPrototypeOf2["default"])(t).constructor) : o.apply(t, e)); }
+function _isNativeReflectConstruct() { try { var t = !Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); } catch (t) {} return (_isNativeReflectConstruct = function _isNativeReflectConstruct() { return !!t; })(); } /* eslint-disable no-unused-vars */
 /* eslint-enable no-unused-vars */
 var MTableGroupbar = /*#__PURE__*/function (_React$Component) {
-  (0, _inherits2["default"])(MTableGroupbar, _React$Component);
-
-  var _super = _createSuper(MTableGroupbar);
-
   function MTableGroupbar(props) {
     var _this;
-
     (0, _classCallCheck2["default"])(this, MTableGroupbar);
-    _this = _super.call(this, props);
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "getItemStyle", function (isDragging, draggableStyle) {
+    _this = _callSuper(this, MTableGroupbar, [props]);
+    (0, _defineProperty2["default"])(_this, "getItemStyle", function (isDragging, draggableStyle) {
       return (0, _objectSpread2["default"])({
         // some basic styles to make the items look a bit nicer
         userSelect: "none",
@@ -62,7 +38,7 @@ var MTableGroupbar = /*#__PURE__*/function (_React$Component) {
         margin: "0 ".concat(8, "px 0 0")
       }, draggableStyle);
     });
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "getListStyle", function (isDraggingOver) {
+    (0, _defineProperty2["default"])(_this, "getListStyle", function (isDraggingOver) {
       return {
         // background: isDraggingOver ? 'lightblue' : '#0000000a',
         background: "#0000000a",
@@ -77,12 +53,11 @@ var MTableGroupbar = /*#__PURE__*/function (_React$Component) {
     _this.state = {};
     return _this;
   }
-
-  (0, _createClass2["default"])(MTableGroupbar, [{
+  (0, _inherits2["default"])(MTableGroupbar, _React$Component);
+  return (0, _createClass2["default"])(MTableGroupbar, [{
     key: "render",
     value: function render() {
       var _this2 = this;
-
       return /*#__PURE__*/React.createElement(_Toolbar["default"], {
         style: {
           padding: 0,
@@ -149,9 +124,7 @@ var MTableGroupbar = /*#__PURE__*/function (_React$Component) {
       }));
     }
   }]);
-  return MTableGroupbar;
 }(React.Component);
-
 MTableGroupbar.defaultProps = {};
 MTableGroupbar.propTypes = {
   localization: _propTypes["default"].shape({
@@ -159,5 +132,4 @@ MTableGroupbar.propTypes = {
     placeholder: _propTypes["default"].string
   })
 };
-var _default = MTableGroupbar;
-exports["default"] = _default;
+var _default = exports["default"] = MTableGroupbar;

--- a/dist/components/m-table-header.js
+++ b/dist/components/m-table-header.js
@@ -1,94 +1,63 @@
 "use strict";
 
-var _interopRequireWildcard = require("@babel/runtime/helpers/interopRequireWildcard");
-
 var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
-
+var _typeof = require("@babel/runtime/helpers/typeof");
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports["default"] = exports.styles = exports.MTableHeader = void 0;
-
+exports.styles = exports["default"] = exports.MTableHeader = void 0;
 var _extends2 = _interopRequireDefault(require("@babel/runtime/helpers/extends"));
-
 var _objectSpread2 = _interopRequireDefault(require("@babel/runtime/helpers/objectSpread"));
-
 var _classCallCheck2 = _interopRequireDefault(require("@babel/runtime/helpers/classCallCheck"));
-
 var _createClass2 = _interopRequireDefault(require("@babel/runtime/helpers/createClass"));
-
-var _assertThisInitialized2 = _interopRequireDefault(require("@babel/runtime/helpers/assertThisInitialized"));
-
-var _inherits2 = _interopRequireDefault(require("@babel/runtime/helpers/inherits"));
-
 var _possibleConstructorReturn2 = _interopRequireDefault(require("@babel/runtime/helpers/possibleConstructorReturn"));
-
 var _getPrototypeOf2 = _interopRequireDefault(require("@babel/runtime/helpers/getPrototypeOf"));
-
+var _inherits2 = _interopRequireDefault(require("@babel/runtime/helpers/inherits"));
 var _defineProperty2 = _interopRequireDefault(require("@babel/runtime/helpers/defineProperty"));
-
 var React = _interopRequireWildcard(require("react"));
-
 var _propTypes = _interopRequireDefault(require("prop-types"));
-
 var _TableHead = _interopRequireDefault(require("@material-ui/core/TableHead"));
-
 var _TableRow = _interopRequireDefault(require("@material-ui/core/TableRow"));
-
 var _TableCell = _interopRequireDefault(require("@material-ui/core/TableCell"));
-
 var _TableSortLabel = _interopRequireDefault(require("@material-ui/core/TableSortLabel"));
-
 var _Checkbox = _interopRequireDefault(require("@material-ui/core/Checkbox"));
-
 var _withStyles = _interopRequireDefault(require("@material-ui/core/styles/withStyles"));
-
 var _reactBeautifulDnd = require("react-beautiful-dnd");
-
 var _core = require("@material-ui/core");
-
 var CommonValues = _interopRequireWildcard(require("../utils/common-values"));
-
-function _createSuper(Derived) { var hasNativeReflectConstruct = _isNativeReflectConstruct(); return function _createSuperInternal() { var Super = (0, _getPrototypeOf2["default"])(Derived), result; if (hasNativeReflectConstruct) { var NewTarget = (0, _getPrototypeOf2["default"])(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return (0, _possibleConstructorReturn2["default"])(this, result); }; }
-
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
-
+function _getRequireWildcardCache(e) { if ("function" != typeof WeakMap) return null; var r = new WeakMap(), t = new WeakMap(); return (_getRequireWildcardCache = function _getRequireWildcardCache(e) { return e ? t : r; })(e); }
+function _interopRequireWildcard(e, r) { if (!r && e && e.__esModule) return e; if (null === e || "object" != _typeof(e) && "function" != typeof e) return { "default": e }; var t = _getRequireWildcardCache(r); if (t && t.has(e)) return t.get(e); var n = { __proto__: null }, a = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var u in e) if ("default" !== u && {}.hasOwnProperty.call(e, u)) { var i = a ? Object.getOwnPropertyDescriptor(e, u) : null; i && (i.get || i.set) ? Object.defineProperty(n, u, i) : n[u] = e[u]; } return n["default"] = e, t && t.set(e, n), n; }
+function _callSuper(t, o, e) { return o = (0, _getPrototypeOf2["default"])(o), (0, _possibleConstructorReturn2["default"])(t, _isNativeReflectConstruct() ? Reflect.construct(o, e || [], (0, _getPrototypeOf2["default"])(t).constructor) : o.apply(t, e)); }
+function _isNativeReflectConstruct() { try { var t = !Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); } catch (t) {} return (_isNativeReflectConstruct = function _isNativeReflectConstruct() { return !!t; })(); } /* eslint-disable no-unused-vars */
 /* eslint-enable no-unused-vars */
-var MTableHeader = /*#__PURE__*/function (_React$Component) {
-  (0, _inherits2["default"])(MTableHeader, _React$Component);
-
-  var _super = _createSuper(MTableHeader);
-
+var MTableHeader = exports.MTableHeader = /*#__PURE__*/function (_React$Component) {
   function MTableHeader(props) {
     var _this;
-
     (0, _classCallCheck2["default"])(this, MTableHeader);
-    _this = _super.call(this, props);
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "handleMouseDown", function (e, columnDef) {
+    _this = _callSuper(this, MTableHeader, [props]);
+    (0, _defineProperty2["default"])(_this, "handleMouseDown", function (e, columnDef) {
       _this.setState({
         lastAdditionalWidth: columnDef.tableData.additionalWidth,
         lastX: e.clientX,
         resizingColumnDef: columnDef
       });
     });
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "handleMouseMove", function (e) {
+    (0, _defineProperty2["default"])(_this, "handleMouseMove", function (e) {
       if (!_this.state.resizingColumnDef) {
         return;
       }
-
       var additionalWidth = _this.state.lastAdditionalWidth + e.clientX - _this.state.lastX;
       additionalWidth = Math.min(_this.state.resizingColumnDef.maxWidth || additionalWidth, additionalWidth);
-
       if (_this.state.resizingColumnDef.tableData.additionalWidth !== additionalWidth) {
         _this.props.onColumnResized(_this.state.resizingColumnDef.tableData.id, additionalWidth);
       }
     });
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "handleMouseUp", function (e) {
+    (0, _defineProperty2["default"])(_this, "handleMouseUp", function (e) {
       _this.setState({
         resizingColumnDef: undefined
       });
     });
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "getCellStyle", function (columnDef) {
+    (0, _defineProperty2["default"])(_this, "getCellStyle", function (columnDef) {
       var width = CommonValues.reducePercentsInCalc(columnDef.tableData.width, _this.props.scrollWidth);
       var style = (0, _objectSpread2["default"])({}, _this.props.headerStyle, columnDef.headerStyle, {
         boxSizing: "border-box",
@@ -96,11 +65,9 @@ var MTableHeader = /*#__PURE__*/function (_React$Component) {
         maxWidth: columnDef.maxWidth,
         minWidth: columnDef.minWidth
       });
-
       if (_this.props.options.tableLayout === "fixed" && _this.props.options.columnResizable && columnDef.resizable !== false) {
         style.paddingRight = 2;
       }
-
       return style;
     });
     _this.state = {
@@ -109,8 +76,8 @@ var MTableHeader = /*#__PURE__*/function (_React$Component) {
     };
     return _this;
   }
-
-  (0, _createClass2["default"])(MTableHeader, [{
+  (0, _inherits2["default"])(MTableHeader, _React$Component);
+  return (0, _createClass2["default"])(MTableHeader, [{
     key: "componentDidMount",
     value: function componentDidMount() {
       document.addEventListener("mousemove", this.handleMouseMove);
@@ -126,15 +93,13 @@ var MTableHeader = /*#__PURE__*/function (_React$Component) {
     key: "renderHeader",
     value: function renderHeader() {
       var _this2 = this;
-
       var size = this.props.options.padding === "default" ? "medium" : "small";
       var mapArr = this.props.columns.filter(function (columnDef) {
-        return !columnDef.hidden && !(columnDef.tableData.groupOrder > -1 && !_this2.props.options.showGroupedColumnsWhileGrouped);
+        return !columnDef.hidden && (_this2.props.options.showGroupedColumnsWhileGrouped || columnDef.tableData.groupOrder === -1);
       }).sort(function (a, b) {
         return a.tableData.columnOrder - b.tableData.columnOrder;
       }).map(function (columnDef, index) {
         var content = columnDef.title;
-
         if (_this2.props.draggable) {
           content = /*#__PURE__*/React.createElement(_reactBeautifulDnd.Draggable, {
             key: columnDef.tableData.id,
@@ -146,7 +111,6 @@ var MTableHeader = /*#__PURE__*/function (_React$Component) {
             }, provided.draggableProps, provided.dragHandleProps), columnDef.title);
           });
         }
-
         if (columnDef.sorting !== false && _this2.props.sorting) {
           content = /*#__PURE__*/React.createElement(_TableSortLabel["default"], {
             IconComponent: _this2.props.icons.SortArrow,
@@ -154,19 +118,16 @@ var MTableHeader = /*#__PURE__*/function (_React$Component) {
             direction: _this2.props.orderDirection || "asc",
             onClick: function onClick() {
               var orderDirection = columnDef.tableData.id !== _this2.props.orderBy ? "asc" : _this2.props.orderDirection === "asc" ? "desc" : _this2.props.orderDirection === "desc" && _this2.props.thirdSortClick ? "" : _this2.props.orderDirection === "desc" && !_this2.props.thirdSortClick ? "asc" : _this2.props.orderDirection === "" ? "asc" : "desc";
-
               _this2.props.onOrderChange(columnDef.tableData.id, orderDirection);
             }
           }, content);
         }
-
         if (columnDef.tooltip) {
           content = /*#__PURE__*/React.createElement(_core.Tooltip, {
             title: columnDef.tooltip,
             placement: "bottom"
           }, /*#__PURE__*/React.createElement("span", null, content));
         }
-
         if (_this2.props.options.tableLayout === "fixed" && _this2.props.options.columnResizable && columnDef.resizable !== false) {
           content = /*#__PURE__*/React.createElement("div", {
             style: {
@@ -187,7 +148,6 @@ var MTableHeader = /*#__PURE__*/function (_React$Component) {
             }
           }));
         }
-
         var cellAlignment = columnDef.align !== undefined ? columnDef.align : ["numeric", "currency"].indexOf(columnDef.type) !== -1 ? "right" : "left";
         return /*#__PURE__*/React.createElement(_TableCell["default"], {
           key: columnDef.tableData.id,
@@ -222,7 +182,6 @@ var MTableHeader = /*#__PURE__*/function (_React$Component) {
     key: "renderSelectionHeader",
     value: function renderSelectionHeader() {
       var _this3 = this;
-
       var selectionWidth = CommonValues.selectionMaxWidth(this.props, this.props.treeDataMaxLevel);
       return /*#__PURE__*/React.createElement(_TableCell["default"], {
         padding: "none",
@@ -253,31 +212,26 @@ var MTableHeader = /*#__PURE__*/function (_React$Component) {
     key: "render",
     value: function render() {
       var _this4 = this;
-
       // const log = this.props.columns.map(c => c.field + ": " + c.tableData.width + ", " + c.tableData.initialWidth + ", " + c.tableData.additionalWidth).join('\r\n');
       // console.log("===============================");
       // console.log(log);
       // console.log("===============================");
-      var headers = this.renderHeader();
 
+      var headers = this.renderHeader();
       if (this.props.hasSelection) {
         headers.splice(0, 0, this.renderSelectionHeader());
       }
-
       if (this.props.showActionsColumn) {
         if (this.props.actionsHeaderIndex >= 0) {
           var endPos = 0;
-
           if (this.props.hasSelection) {
             endPos = 1;
           }
-
           headers.splice(this.props.actionsHeaderIndex + endPos, 0, this.renderActionsHeader());
         } else if (this.props.actionsHeaderIndex === -1) {
           headers.push(this.renderActionsHeader());
         }
       }
-
       if (this.props.hasDetailPanel) {
         if (this.props.detailPanelColumnAlignment === "right") {
           headers.push(this.renderDetailPanelColumnCell());
@@ -285,7 +239,6 @@ var MTableHeader = /*#__PURE__*/function (_React$Component) {
           headers.splice(0, 0, this.renderDetailPanelColumnCell());
         }
       }
-
       if (this.props.isTreeData > 0) {
         headers.splice(0, 0, /*#__PURE__*/React.createElement(_TableCell["default"], {
           padding: "none",
@@ -294,7 +247,6 @@ var MTableHeader = /*#__PURE__*/function (_React$Component) {
           style: (0, _objectSpread2["default"])({}, this.props.headerStyle)
         }));
       }
-
       this.props.columns.filter(function (columnDef) {
         return columnDef.tableData.groupOrder > -1;
       }).forEach(function (columnDef) {
@@ -307,10 +259,7 @@ var MTableHeader = /*#__PURE__*/function (_React$Component) {
       return /*#__PURE__*/React.createElement(_TableHead["default"], null, /*#__PURE__*/React.createElement(_TableRow["default"], null, headers));
     }
   }]);
-  return MTableHeader;
 }(React.Component);
-
-exports.MTableHeader = MTableHeader;
 MTableHeader.defaultProps = {
   dataCount: 0,
   hasSelection: false,
@@ -348,8 +297,7 @@ MTableHeader.propTypes = {
   thirdSortClick: _propTypes["default"].bool,
   tooltip: _propTypes["default"].string
 };
-
-var styles = function styles(theme) {
+var styles = exports.styles = function styles(theme) {
   return {
     header: {
       // display: 'inline-block',
@@ -357,15 +305,9 @@ var styles = function styles(theme) {
       top: 0,
       zIndex: 10,
       backgroundColor: theme.palette.background.paper // Change according to theme,
-
     }
   };
 };
-
-exports.styles = styles;
-
-var _default = (0, _withStyles["default"])(styles, {
+var _default = exports["default"] = (0, _withStyles["default"])(styles, {
   withTheme: true
 })(MTableHeader);
-
-exports["default"] = _default;

--- a/dist/components/m-table-pagination.js
+++ b/dist/components/m-table-pagination.js
@@ -1,87 +1,62 @@
 "use strict";
 
-var _interopRequireWildcard = require("@babel/runtime/helpers/interopRequireWildcard");
-
 var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
-
+var _typeof = require("@babel/runtime/helpers/typeof");
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports["default"] = void 0;
-
 var _objectSpread2 = _interopRequireDefault(require("@babel/runtime/helpers/objectSpread"));
-
 var _classCallCheck2 = _interopRequireDefault(require("@babel/runtime/helpers/classCallCheck"));
-
 var _createClass2 = _interopRequireDefault(require("@babel/runtime/helpers/createClass"));
-
-var _assertThisInitialized2 = _interopRequireDefault(require("@babel/runtime/helpers/assertThisInitialized"));
-
-var _inherits2 = _interopRequireDefault(require("@babel/runtime/helpers/inherits"));
-
 var _possibleConstructorReturn2 = _interopRequireDefault(require("@babel/runtime/helpers/possibleConstructorReturn"));
-
 var _getPrototypeOf2 = _interopRequireDefault(require("@babel/runtime/helpers/getPrototypeOf"));
-
+var _inherits2 = _interopRequireDefault(require("@babel/runtime/helpers/inherits"));
 var _defineProperty2 = _interopRequireDefault(require("@babel/runtime/helpers/defineProperty"));
-
 var _IconButton = _interopRequireDefault(require("@material-ui/core/IconButton"));
-
 var _withStyles = _interopRequireDefault(require("@material-ui/core/styles/withStyles"));
-
 var _Tooltip = _interopRequireDefault(require("@material-ui/core/Tooltip"));
-
 var _Typography = _interopRequireDefault(require("@material-ui/core/Typography"));
-
 var _propTypes = _interopRequireDefault(require("prop-types"));
-
 var React = _interopRequireWildcard(require("react"));
-
-function _createSuper(Derived) { var hasNativeReflectConstruct = _isNativeReflectConstruct(); return function _createSuperInternal() { var Super = (0, _getPrototypeOf2["default"])(Derived), result; if (hasNativeReflectConstruct) { var NewTarget = (0, _getPrototypeOf2["default"])(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return (0, _possibleConstructorReturn2["default"])(this, result); }; }
-
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
-
+function _getRequireWildcardCache(e) { if ("function" != typeof WeakMap) return null; var r = new WeakMap(), t = new WeakMap(); return (_getRequireWildcardCache = function _getRequireWildcardCache(e) { return e ? t : r; })(e); }
+function _interopRequireWildcard(e, r) { if (!r && e && e.__esModule) return e; if (null === e || "object" != _typeof(e) && "function" != typeof e) return { "default": e }; var t = _getRequireWildcardCache(r); if (t && t.has(e)) return t.get(e); var n = { __proto__: null }, a = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var u in e) if ("default" !== u && {}.hasOwnProperty.call(e, u)) { var i = a ? Object.getOwnPropertyDescriptor(e, u) : null; i && (i.get || i.set) ? Object.defineProperty(n, u, i) : n[u] = e[u]; } return n["default"] = e, t && t.set(e, n), n; }
+function _callSuper(t, o, e) { return o = (0, _getPrototypeOf2["default"])(o), (0, _possibleConstructorReturn2["default"])(t, _isNativeReflectConstruct() ? Reflect.construct(o, e || [], (0, _getPrototypeOf2["default"])(t).constructor) : o.apply(t, e)); }
+function _isNativeReflectConstruct() { try { var t = !Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); } catch (t) {} return (_isNativeReflectConstruct = function _isNativeReflectConstruct() { return !!t; })(); } /* eslint-disable no-unused-vars */
 /* eslint-enable no-unused-vars */
 var MTablePaginationInner = /*#__PURE__*/function (_React$Component) {
-  (0, _inherits2["default"])(MTablePaginationInner, _React$Component);
-
-  var _super = _createSuper(MTablePaginationInner);
-
   function MTablePaginationInner() {
     var _this;
-
     (0, _classCallCheck2["default"])(this, MTablePaginationInner);
-
     for (var _len = arguments.length, args = new Array(_len), _key = 0; _key < _len; _key++) {
       args[_key] = arguments[_key];
     }
-
-    _this = _super.call.apply(_super, [this].concat(args));
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "handleFirstPageButtonClick", function (event) {
+    _this = _callSuper(this, MTablePaginationInner, [].concat(args));
+    (0, _defineProperty2["default"])(_this, "handleFirstPageButtonClick", function (event) {
       _this.props.onChangePage(event, 0);
     });
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "handleBackButtonClick", function (event) {
+    (0, _defineProperty2["default"])(_this, "handleBackButtonClick", function (event) {
       _this.props.onChangePage(event, _this.props.page - 1);
     });
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "handleNextButtonClick", function (event) {
+    (0, _defineProperty2["default"])(_this, "handleNextButtonClick", function (event) {
       _this.props.onChangePage(event, _this.props.page + 1);
     });
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "handleLastPageButtonClick", function (event) {
+    (0, _defineProperty2["default"])(_this, "handleLastPageButtonClick", function (event) {
       _this.props.onChangePage(event, Math.max(0, Math.ceil(_this.props.count / _this.props.rowsPerPage) - 1));
     });
     return _this;
   }
-
-  (0, _createClass2["default"])(MTablePaginationInner, [{
+  (0, _inherits2["default"])(MTablePaginationInner, _React$Component);
+  return (0, _createClass2["default"])(MTablePaginationInner, [{
     key: "render",
     value: function render() {
       var _this$props = this.props,
-          classes = _this$props.classes,
-          count = _this$props.count,
-          page = _this$props.page,
-          rowsPerPage = _this$props.rowsPerPage,
-          theme = _this$props.theme,
-          showFirstLastPageButtons = _this$props.showFirstLastPageButtons;
+        classes = _this$props.classes,
+        count = _this$props.count,
+        page = _this$props.page,
+        rowsPerPage = _this$props.rowsPerPage,
+        theme = _this$props.theme,
+        showFirstLastPageButtons = _this$props.showFirstLastPageButtons;
       var localization = (0, _objectSpread2["default"])({}, MTablePaginationInner.defaultProps.localization, this.props.localization);
       return /*#__PURE__*/React.createElement("div", {
         className: classes.root
@@ -120,20 +95,17 @@ var MTablePaginationInner = /*#__PURE__*/function (_React$Component) {
       }, theme.direction === "rtl" ? /*#__PURE__*/React.createElement(this.props.icons.FirstPage, null) : /*#__PURE__*/React.createElement(this.props.icons.LastPage, null)))));
     }
   }]);
-  return MTablePaginationInner;
 }(React.Component);
-
 var actionsStyles = function actionsStyles(theme) {
   return {
     root: {
       flexShrink: 0,
       color: theme.palette.text.secondary,
-      display: "flex" // lineHeight: '48px'
-
+      display: "flex"
+      // lineHeight: '48px'
     }
   };
 };
-
 MTablePaginationInner.propTypes = {
   onChangePage: _propTypes["default"].func,
   page: _propTypes["default"].number,
@@ -158,5 +130,4 @@ MTablePaginationInner.defaultProps = {
 var MTablePagination = (0, _withStyles["default"])(actionsStyles, {
   withTheme: true
 })(MTablePaginationInner);
-var _default = MTablePagination;
-exports["default"] = _default;
+var _default = exports["default"] = MTablePagination;

--- a/dist/components/m-table-stepped-pagination.js
+++ b/dist/components/m-table-stepped-pagination.js
@@ -1,89 +1,62 @@
 "use strict";
 
-var _interopRequireWildcard = require("@babel/runtime/helpers/interopRequireWildcard");
-
 var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
-
+var _typeof = require("@babel/runtime/helpers/typeof");
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports["default"] = void 0;
-
 var _objectSpread2 = _interopRequireDefault(require("@babel/runtime/helpers/objectSpread"));
-
 var _classCallCheck2 = _interopRequireDefault(require("@babel/runtime/helpers/classCallCheck"));
-
 var _createClass2 = _interopRequireDefault(require("@babel/runtime/helpers/createClass"));
-
-var _assertThisInitialized2 = _interopRequireDefault(require("@babel/runtime/helpers/assertThisInitialized"));
-
-var _inherits2 = _interopRequireDefault(require("@babel/runtime/helpers/inherits"));
-
 var _possibleConstructorReturn2 = _interopRequireDefault(require("@babel/runtime/helpers/possibleConstructorReturn"));
-
 var _getPrototypeOf2 = _interopRequireDefault(require("@babel/runtime/helpers/getPrototypeOf"));
-
+var _inherits2 = _interopRequireDefault(require("@babel/runtime/helpers/inherits"));
 var _defineProperty2 = _interopRequireDefault(require("@babel/runtime/helpers/defineProperty"));
-
 var _IconButton = _interopRequireDefault(require("@material-ui/core/IconButton"));
-
 var _withStyles = _interopRequireDefault(require("@material-ui/core/styles/withStyles"));
-
 var _Tooltip = _interopRequireDefault(require("@material-ui/core/Tooltip"));
-
 var _Hidden = _interopRequireDefault(require("@material-ui/core/Hidden"));
-
 var _Button = _interopRequireDefault(require("@material-ui/core/Button"));
-
 var _propTypes = _interopRequireDefault(require("prop-types"));
-
 var React = _interopRequireWildcard(require("react"));
-
-function _createSuper(Derived) { var hasNativeReflectConstruct = _isNativeReflectConstruct(); return function _createSuperInternal() { var Super = (0, _getPrototypeOf2["default"])(Derived), result; if (hasNativeReflectConstruct) { var NewTarget = (0, _getPrototypeOf2["default"])(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return (0, _possibleConstructorReturn2["default"])(this, result); }; }
-
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
-
+function _getRequireWildcardCache(e) { if ("function" != typeof WeakMap) return null; var r = new WeakMap(), t = new WeakMap(); return (_getRequireWildcardCache = function _getRequireWildcardCache(e) { return e ? t : r; })(e); }
+function _interopRequireWildcard(e, r) { if (!r && e && e.__esModule) return e; if (null === e || "object" != _typeof(e) && "function" != typeof e) return { "default": e }; var t = _getRequireWildcardCache(r); if (t && t.has(e)) return t.get(e); var n = { __proto__: null }, a = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var u in e) if ("default" !== u && {}.hasOwnProperty.call(e, u)) { var i = a ? Object.getOwnPropertyDescriptor(e, u) : null; i && (i.get || i.set) ? Object.defineProperty(n, u, i) : n[u] = e[u]; } return n["default"] = e, t && t.set(e, n), n; }
+function _callSuper(t, o, e) { return o = (0, _getPrototypeOf2["default"])(o), (0, _possibleConstructorReturn2["default"])(t, _isNativeReflectConstruct() ? Reflect.construct(o, e || [], (0, _getPrototypeOf2["default"])(t).constructor) : o.apply(t, e)); }
+function _isNativeReflectConstruct() { try { var t = !Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); } catch (t) {} return (_isNativeReflectConstruct = function _isNativeReflectConstruct() { return !!t; })(); } /* eslint-disable no-unused-vars */
 /* eslint-enable no-unused-vars */
 var MTablePaginationInner = /*#__PURE__*/function (_React$Component) {
-  (0, _inherits2["default"])(MTablePaginationInner, _React$Component);
-
-  var _super = _createSuper(MTablePaginationInner);
-
   function MTablePaginationInner() {
     var _this;
-
     (0, _classCallCheck2["default"])(this, MTablePaginationInner);
-
     for (var _len = arguments.length, args = new Array(_len), _key = 0; _key < _len; _key++) {
       args[_key] = arguments[_key];
     }
-
-    _this = _super.call.apply(_super, [this].concat(args));
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "handleFirstPageButtonClick", function (event) {
+    _this = _callSuper(this, MTablePaginationInner, [].concat(args));
+    (0, _defineProperty2["default"])(_this, "handleFirstPageButtonClick", function (event) {
       _this.props.onChangePage(event, 0);
     });
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "handleBackButtonClick", function (event) {
+    (0, _defineProperty2["default"])(_this, "handleBackButtonClick", function (event) {
       _this.props.onChangePage(event, _this.props.page - 1);
     });
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "handleNextButtonClick", function (event) {
+    (0, _defineProperty2["default"])(_this, "handleNextButtonClick", function (event) {
       _this.props.onChangePage(event, _this.props.page + 1);
     });
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "handleNumberButtonClick", function (number) {
+    (0, _defineProperty2["default"])(_this, "handleNumberButtonClick", function (number) {
       return function (event) {
         _this.props.onChangePage(event, number);
       };
     });
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "handleLastPageButtonClick", function (event) {
+    (0, _defineProperty2["default"])(_this, "handleLastPageButtonClick", function (event) {
       _this.props.onChangePage(event, Math.max(0, Math.ceil(_this.props.count / _this.props.rowsPerPage) - 1));
     });
     return _this;
   }
-
-  (0, _createClass2["default"])(MTablePaginationInner, [{
+  (0, _inherits2["default"])(MTablePaginationInner, _React$Component);
+  return (0, _createClass2["default"])(MTablePaginationInner, [{
     key: "renderPagesButton",
     value: function renderPagesButton(start, end) {
       var buttons = [];
-
       for (var p = start; p <= end; p++) {
         var buttonVariant = p === this.props.page ? "contained" : "text";
         buttons.push( /*#__PURE__*/React.createElement(_Button["default"], {
@@ -101,19 +74,18 @@ var MTablePaginationInner = /*#__PURE__*/function (_React$Component) {
           key: p
         }, p + 1));
       }
-
       return /*#__PURE__*/React.createElement("span", null, buttons);
     }
   }, {
     key: "render",
     value: function render() {
       var _this$props = this.props,
-          classes = _this$props.classes,
-          count = _this$props.count,
-          page = _this$props.page,
-          rowsPerPage = _this$props.rowsPerPage,
-          theme = _this$props.theme,
-          showFirstLastPageButtons = _this$props.showFirstLastPageButtons;
+        classes = _this$props.classes,
+        count = _this$props.count,
+        page = _this$props.page,
+        rowsPerPage = _this$props.rowsPerPage,
+        theme = _this$props.theme,
+        showFirstLastPageButtons = _this$props.showFirstLastPageButtons;
       var localization = (0, _objectSpread2["default"])({}, MTablePaginationInner.defaultProps.localization, this.props.localization);
       var maxPages = Math.ceil(count / rowsPerPage) - 1;
       var pageStart = Math.max(page - 1, 0);
@@ -149,9 +121,7 @@ var MTablePaginationInner = /*#__PURE__*/function (_React$Component) {
       }, theme.direction === "rtl" ? /*#__PURE__*/React.createElement(this.props.icons.FirstPage, null) : /*#__PURE__*/React.createElement(this.props.icons.LastPage, null)))));
     }
   }]);
-  return MTablePaginationInner;
 }(React.Component);
-
 var actionsStyles = function actionsStyles(theme) {
   return {
     root: {
@@ -161,7 +131,6 @@ var actionsStyles = function actionsStyles(theme) {
     }
   };
 };
-
 MTablePaginationInner.propTypes = {
   onChangePage: _propTypes["default"].func,
   page: _propTypes["default"].number,
@@ -186,5 +155,4 @@ MTablePaginationInner.defaultProps = {
 var MTableSteppedPagination = (0, _withStyles["default"])(actionsStyles, {
   withTheme: true
 })(MTablePaginationInner);
-var _default = MTableSteppedPagination;
-exports["default"] = _default;
+var _default = exports["default"] = MTableSteppedPagination;

--- a/dist/components/m-table-toolbar.js
+++ b/dist/components/m-table-toolbar.js
@@ -1,106 +1,65 @@
 "use strict";
 
-var _interopRequireWildcard = require("@babel/runtime/helpers/interopRequireWildcard");
-
 var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
-
+var _typeof = require("@babel/runtime/helpers/typeof");
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports["default"] = exports.styles = exports.MTableToolbar = void 0;
-
+exports.styles = exports["default"] = exports.MTableToolbar = void 0;
 var _objectSpread2 = _interopRequireDefault(require("@babel/runtime/helpers/objectSpread"));
-
 var _slicedToArray2 = _interopRequireDefault(require("@babel/runtime/helpers/slicedToArray"));
-
 var _toConsumableArray2 = _interopRequireDefault(require("@babel/runtime/helpers/toConsumableArray"));
-
 var _classCallCheck2 = _interopRequireDefault(require("@babel/runtime/helpers/classCallCheck"));
-
 var _createClass2 = _interopRequireDefault(require("@babel/runtime/helpers/createClass"));
-
-var _assertThisInitialized2 = _interopRequireDefault(require("@babel/runtime/helpers/assertThisInitialized"));
-
-var _inherits2 = _interopRequireDefault(require("@babel/runtime/helpers/inherits"));
-
 var _possibleConstructorReturn2 = _interopRequireDefault(require("@babel/runtime/helpers/possibleConstructorReturn"));
-
 var _getPrototypeOf2 = _interopRequireDefault(require("@babel/runtime/helpers/getPrototypeOf"));
-
+var _inherits2 = _interopRequireDefault(require("@babel/runtime/helpers/inherits"));
 var _defineProperty2 = _interopRequireDefault(require("@babel/runtime/helpers/defineProperty"));
-
 var _Checkbox = _interopRequireDefault(require("@material-ui/core/Checkbox"));
-
 var _FormControlLabel = _interopRequireDefault(require("@material-ui/core/FormControlLabel"));
-
 var _IconButton = _interopRequireDefault(require("@material-ui/core/IconButton"));
-
 var _InputAdornment = _interopRequireDefault(require("@material-ui/core/InputAdornment"));
-
 var _Menu = _interopRequireDefault(require("@material-ui/core/Menu"));
-
 var _MenuItem = _interopRequireDefault(require("@material-ui/core/MenuItem"));
-
 var _TextField = _interopRequireDefault(require("@material-ui/core/TextField"));
-
 var _Toolbar = _interopRequireDefault(require("@material-ui/core/Toolbar"));
-
 var _Tooltip = _interopRequireDefault(require("@material-ui/core/Tooltip"));
-
 var _Typography = _interopRequireDefault(require("@material-ui/core/Typography"));
-
 var _withStyles = _interopRequireDefault(require("@material-ui/core/styles/withStyles"));
-
 var _colorManipulator = require("@material-ui/core/styles/colorManipulator");
-
 var _classnames = _interopRequireDefault(require("classnames"));
-
 var _filefy = require("filefy");
-
 var _propTypes = _interopRequireWildcard(require("prop-types"));
-
 require("jspdf-autotable");
-
 var React = _interopRequireWildcard(require("react"));
-
-function _createSuper(Derived) { var hasNativeReflectConstruct = _isNativeReflectConstruct(); return function _createSuperInternal() { var Super = (0, _getPrototypeOf2["default"])(Derived), result; if (hasNativeReflectConstruct) { var NewTarget = (0, _getPrototypeOf2["default"])(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return (0, _possibleConstructorReturn2["default"])(this, result); }; }
-
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
-
+function _getRequireWildcardCache(e) { if ("function" != typeof WeakMap) return null; var r = new WeakMap(), t = new WeakMap(); return (_getRequireWildcardCache = function _getRequireWildcardCache(e) { return e ? t : r; })(e); }
+function _interopRequireWildcard(e, r) { if (!r && e && e.__esModule) return e; if (null === e || "object" != _typeof(e) && "function" != typeof e) return { "default": e }; var t = _getRequireWildcardCache(r); if (t && t.has(e)) return t.get(e); var n = { __proto__: null }, a = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var u in e) if ("default" !== u && {}.hasOwnProperty.call(e, u)) { var i = a ? Object.getOwnPropertyDescriptor(e, u) : null; i && (i.get || i.set) ? Object.defineProperty(n, u, i) : n[u] = e[u]; } return n["default"] = e, t && t.set(e, n), n; }
+function _callSuper(t, o, e) { return o = (0, _getPrototypeOf2["default"])(o), (0, _possibleConstructorReturn2["default"])(t, _isNativeReflectConstruct() ? Reflect.construct(o, e || [], (0, _getPrototypeOf2["default"])(t).constructor) : o.apply(t, e)); }
+function _isNativeReflectConstruct() { try { var t = !Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); } catch (t) {} return (_isNativeReflectConstruct = function _isNativeReflectConstruct() { return !!t; })(); } /* eslint-disable no-unused-vars */
 var jsPDF = typeof window !== "undefined" ? require("jspdf").jsPDF : null;
 /* eslint-enable no-unused-vars */
-
-var MTableToolbar = /*#__PURE__*/function (_React$Component) {
-  (0, _inherits2["default"])(MTableToolbar, _React$Component);
-
-  var _super = _createSuper(MTableToolbar);
-
+var MTableToolbar = exports.MTableToolbar = /*#__PURE__*/function (_React$Component) {
   function MTableToolbar(props) {
     var _this;
-
     (0, _classCallCheck2["default"])(this, MTableToolbar);
-    _this = _super.call(this, props);
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "onSearchChange", function (searchText) {
+    _this = _callSuper(this, MTableToolbar, [props]);
+    (0, _defineProperty2["default"])(_this, "onSearchChange", function (searchText) {
       _this.props.dataManager.changeSearchText(searchText);
-
       _this.setState({
         searchText: searchText
       }, _this.props.onSearchChanged(searchText));
     });
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "getTableData", function () {
+    (0, _defineProperty2["default"])(_this, "getTableData", function () {
       var _ref = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {},
-          isForExport = _ref.isForExport;
-
+        isForExport = _ref.isForExport;
       var columns = _this.props.columns.filter(function (columnDef) {
         return (!columnDef.hidden || columnDef["export"] === true) && columnDef["export"] !== false && (columnDef.field || columnDef.getExportValue);
       }).sort(function (a, b) {
         return a.tableData.columnOrder > b.tableData.columnOrder ? 1 : -1;
       });
-
       var mappableData = _this.props.exportAllData ? _this.props.data : _this.props.renderData;
-
       if (isForExport && _this.props.exportGroupsFlattened) {
-        var recursiveFlatten = function recursiveFlatten(rowData) {
+        var _recursiveFlatten = function recursiveFlatten(rowData) {
           var children = rowData.groups && Array.isArray(rowData.groups) && rowData.groups.length > 0 ? rowData.groups : rowData.data;
           if (!Array.isArray(children)) return rowData;
           return [_this.props.exportIncludeGroup && {
@@ -108,62 +67,54 @@ var MTableToolbar = /*#__PURE__*/function (_React$Component) {
               return rowData.value;
             }
           }, children.map(function (rowData) {
-            return recursiveFlatten(rowData);
+            return _recursiveFlatten(rowData);
           }).flat()].filter(function (value) {
             return !!value;
           }).flat();
         };
-
         mappableData = mappableData.reduce(function (allData, rowData) {
-          return [].concat((0, _toConsumableArray2["default"])(allData), [recursiveFlatten(rowData)]).filter(function (value) {
+          return [].concat((0, _toConsumableArray2["default"])(allData), [_recursiveFlatten(rowData)]).filter(function (value) {
             return !!value;
           }).flat();
         }, []);
       }
-
       var data = mappableData.map(function (rowData) {
         return columns.map(function (columnDef, index) {
           if (index === 0 && typeof rowData.getGroupValue === "function") {
             return rowData.getGroupValue();
           }
-
           if (typeof columnDef.getExportValue === "function") {
             return columnDef.getExportValue(rowData);
           }
-
           return _this.props.getFieldValue(rowData, columnDef);
         });
       });
       return [columns, data];
     });
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "defaultExportCsv", function () {
+    (0, _defineProperty2["default"])(_this, "defaultExportCsv", function () {
       var _this$getTableData = _this.getTableData({
-        isForExport: true
-      }),
-          _this$getTableData2 = (0, _slicedToArray2["default"])(_this$getTableData, 2),
-          columns = _this$getTableData2[0],
-          data = _this$getTableData2[1];
-
+          isForExport: true
+        }),
+        _this$getTableData2 = (0, _slicedToArray2["default"])(_this$getTableData, 2),
+        columns = _this$getTableData2[0],
+        data = _this$getTableData2[1];
       var fileName = _this.props.title || "data";
-
       if (_this.props.exportFileName) {
         fileName = typeof _this.props.exportFileName === "function" ? _this.props.exportFileName() : _this.props.exportFileName;
       }
-
       var builder = new _filefy.CsvBuilder(fileName + ".csv");
       builder.setDelimeter(_this.props.exportDelimiter).setColumns(columns.map(function (columnDef) {
         return columnDef.title;
       })).addRows(data).exportFile();
     });
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "defaultExportPdf", function () {
+    (0, _defineProperty2["default"])(_this, "defaultExportPdf", function () {
       if (jsPDF !== null) {
         var _this$getTableData3 = _this.getTableData({
-          isForExport: true
-        }),
-            _this$getTableData4 = (0, _slicedToArray2["default"])(_this$getTableData3, 2),
-            columns = _this$getTableData4[0],
-            data = _this$getTableData4[1];
-
+            isForExport: true
+          }),
+          _this$getTableData4 = (0, _slicedToArray2["default"])(_this$getTableData3, 2),
+          columns = _this$getTableData4[0],
+          data = _this$getTableData4[1];
         var content = {
           startY: 50,
           head: [columns.map(function (columnDef) {
@@ -181,24 +132,22 @@ var MTableToolbar = /*#__PURE__*/function (_React$Component) {
         doc.save((_this.props.exportFileName || _this.props.title || "data") + ".pdf");
       }
     });
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "exportCsv", function () {
+    (0, _defineProperty2["default"])(_this, "exportCsv", function () {
       if (_this.props.exportCsv) {
         _this.props.exportCsv(_this.props.columns, _this.props.data);
       } else {
         _this.defaultExportCsv();
       }
-
       _this.setState({
         exportButtonAnchorEl: null
       });
     });
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "exportPdf", function () {
+    (0, _defineProperty2["default"])(_this, "exportPdf", function () {
       if (_this.props.exportPdf) {
         _this.props.exportPdf(_this.props.columns, _this.props.data);
       } else {
         _this.defaultExportPdf();
       }
-
       _this.setState({
         exportButtonAnchorEl: null
       });
@@ -210,14 +159,12 @@ var MTableToolbar = /*#__PURE__*/function (_React$Component) {
     };
     return _this;
   }
-
-  (0, _createClass2["default"])(MTableToolbar, [{
+  (0, _inherits2["default"])(MTableToolbar, _React$Component);
+  return (0, _createClass2["default"])(MTableToolbar, [{
     key: "renderSearch",
     value: function renderSearch() {
       var _this2 = this;
-
       var localization = (0, _objectSpread2["default"])({}, MTableToolbar.defaultProps.localization, this.props.localization);
-
       if (this.props.search) {
         return /*#__PURE__*/React.createElement(_TextField["default"], {
           autoFocus: this.props.searchAutoFocus,
@@ -262,7 +209,6 @@ var MTableToolbar = /*#__PURE__*/function (_React$Component) {
     key: "renderDefaultActions",
     value: function renderDefaultActions() {
       var _this3 = this;
-
       var localization = (0, _objectSpread2["default"])({}, MTableToolbar.defaultProps.localization, this.props.localization);
       var classes = this.props.classes;
       return /*#__PURE__*/React.createElement("div", null, this.props.columnsButton && /*#__PURE__*/React.createElement("span", null, /*#__PURE__*/React.createElement(_Tooltip["default"], {
@@ -308,7 +254,6 @@ var MTableToolbar = /*#__PURE__*/function (_React$Component) {
             }
           }), /*#__PURE__*/React.createElement("span", null, col.title)));
         }
-
         return null;
       }))), this.props.exportButton && /*#__PURE__*/React.createElement("span", null, /*#__PURE__*/React.createElement(_Tooltip["default"], {
         title: localization.exportTitle
@@ -389,10 +334,7 @@ var MTableToolbar = /*#__PURE__*/function (_React$Component) {
       }), this.props.searchFieldAlignment === "right" && this.renderSearch(), this.props.toolbarButtonAlignment === "right" && this.renderActions());
     }
   }]);
-  return MTableToolbar;
 }(React.Component);
-
-exports.MTableToolbar = MTableToolbar;
 MTableToolbar.defaultProps = {
   actions: [],
   columns: [],
@@ -458,8 +400,7 @@ MTableToolbar.propTypes = {
   classes: _propTypes["default"].object,
   searchAutoFocus: _propTypes["default"].bool
 };
-
-var styles = function styles(theme) {
+var styles = exports.styles = function styles(theme) {
   return {
     root: {
       paddingRight: theme.spacing(1)
@@ -490,9 +431,4 @@ var styles = function styles(theme) {
     }
   };
 };
-
-exports.styles = styles;
-
-var _default = (0, _withStyles["default"])(styles)(MTableToolbar);
-
-exports["default"] = _default;
+var _default = exports["default"] = (0, _withStyles["default"])(styles)(MTableToolbar);

--- a/dist/default-props.js
+++ b/dist/default-props.js
@@ -1,34 +1,23 @@
 "use strict";
 
-var _interopRequireWildcard = require("@babel/runtime/helpers/interopRequireWildcard");
-
 var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
-
+var _typeof = require("@babel/runtime/helpers/typeof");
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.defaultProps = void 0;
-
 var _objectSpread2 = _interopRequireDefault(require("@babel/runtime/helpers/objectSpread"));
-
 var _extends2 = _interopRequireDefault(require("@babel/runtime/helpers/extends"));
-
 var _react = _interopRequireDefault(require("react"));
-
 var _CircularProgress = _interopRequireDefault(require("@material-ui/core/CircularProgress"));
-
 var _Icon = _interopRequireDefault(require("@material-ui/core/Icon"));
-
 var _Paper = _interopRequireDefault(require("@material-ui/core/Paper"));
-
 var _TablePagination = _interopRequireDefault(require("@material-ui/core/TablePagination"));
-
 var MComponents = _interopRequireWildcard(require("./components"));
-
 var _propTypes = _interopRequireDefault(require("prop-types"));
-
 var _colorManipulator = require("@material-ui/core/styles/colorManipulator");
-
+function _getRequireWildcardCache(e) { if ("function" != typeof WeakMap) return null; var r = new WeakMap(), t = new WeakMap(); return (_getRequireWildcardCache = function _getRequireWildcardCache(e) { return e ? t : r; })(e); }
+function _interopRequireWildcard(e, r) { if (!r && e && e.__esModule) return e; if (null === e || "object" != _typeof(e) && "function" != typeof e) return { "default": e }; var t = _getRequireWildcardCache(r); if (t && t.has(e)) return t.get(e); var n = { __proto__: null }, a = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var u in e) if ("default" !== u && {}.hasOwnProperty.call(e, u)) { var i = a ? Object.getOwnPropertyDescriptor(e, u) : null; i && (i.get || i.set) ? Object.defineProperty(n, u, i) : n[u] = e[u]; } return n["default"] = e, t && t.set(e, n), n; }
 var OverlayLoading = function OverlayLoading(props) {
   return /*#__PURE__*/_react["default"].createElement("div", {
     style: {
@@ -47,11 +36,9 @@ var OverlayLoading = function OverlayLoading(props) {
     }
   }, /*#__PURE__*/_react["default"].createElement(_CircularProgress["default"], null)));
 };
-
 OverlayLoading.propTypes = {
   theme: _propTypes["default"].any
 };
-
 var OverlayError = function OverlayError(props) {
   return /*#__PURE__*/_react["default"].createElement("div", {
     style: {
@@ -77,21 +64,18 @@ var OverlayError = function OverlayError(props) {
     }
   })));
 };
-
 OverlayError.propTypes = {
   error: _propTypes["default"].oneOfType([_propTypes["default"].object, _propTypes["default"].string]),
   retry: _propTypes["default"].func,
   theme: _propTypes["default"].any,
   icon: _propTypes["default"].any
 };
-
 var Container = function Container(props) {
   return /*#__PURE__*/_react["default"].createElement(_Paper["default"], (0, _extends2["default"])({
     elevation: 2
   }, props));
 };
-
-var defaultProps = {
+var defaultProps = exports.defaultProps = {
   actions: [],
   classes: {},
   columns: [],
@@ -216,7 +200,6 @@ var defaultProps = {
       }), "replay");
     })
     /* eslint-enable react/display-name */
-
   },
   isLoading: false,
   title: "Table Title",
@@ -295,4 +278,3 @@ var defaultProps = {
   },
   style: {}
 };
-exports.defaultProps = defaultProps;

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,7 +1,6 @@
 "use strict";
 
 var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
-
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
@@ -15,23 +14,14 @@ Object.defineProperty(exports, "MTable", {
   }
 });
 exports["default"] = void 0;
-
 var _extends2 = _interopRequireDefault(require("@babel/runtime/helpers/extends"));
-
 require("./utils/polyfill");
-
 var _react = _interopRequireDefault(require("react"));
-
 var _defaultProps = require("./default-props");
-
 var _propTypes = require("./prop-types");
-
 var _materialTable = _interopRequireDefault(require("./material-table"));
-
 var _withStyles = _interopRequireDefault(require("@material-ui/core/styles/withStyles"));
-
 var _components = require("./components");
-
 Object.keys(_components).forEach(function (key) {
   if (key === "default" || key === "__esModule") return;
   if (Object.prototype.hasOwnProperty.call(_exportNames, key)) return;
@@ -45,7 +35,6 @@ Object.keys(_components).forEach(function (key) {
 });
 _materialTable["default"].defaultProps = _defaultProps.defaultProps;
 _materialTable["default"].propTypes = _propTypes.propTypes;
-
 var styles = function styles(theme) {
   return {
     paginationRoot: {
@@ -63,13 +52,10 @@ var styles = function styles(theme) {
     }
   };
 };
-
-var _default = (0, _withStyles["default"])(styles, {
+var _default = exports["default"] = (0, _withStyles["default"])(styles, {
   withTheme: true
 })(function (props) {
   return /*#__PURE__*/_react["default"].createElement(_materialTable["default"], (0, _extends2["default"])({}, props, {
     ref: props.tableRef
   }));
 });
-
-exports["default"] = _default;

--- a/dist/material-table.js
+++ b/dist/material-table.js
@@ -1,108 +1,70 @@
 "use strict";
 
-var _interopRequireWildcard = require("@babel/runtime/helpers/interopRequireWildcard");
-
 var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
-
+var _typeof3 = require("@babel/runtime/helpers/typeof");
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports["default"] = void 0;
-
 var _extends2 = _interopRequireDefault(require("@babel/runtime/helpers/extends"));
-
 var _toConsumableArray2 = _interopRequireDefault(require("@babel/runtime/helpers/toConsumableArray"));
-
 var _typeof2 = _interopRequireDefault(require("@babel/runtime/helpers/typeof"));
-
 var _objectSpread2 = _interopRequireDefault(require("@babel/runtime/helpers/objectSpread"));
-
 var _classCallCheck2 = _interopRequireDefault(require("@babel/runtime/helpers/classCallCheck"));
-
 var _createClass2 = _interopRequireDefault(require("@babel/runtime/helpers/createClass"));
-
-var _assertThisInitialized2 = _interopRequireDefault(require("@babel/runtime/helpers/assertThisInitialized"));
-
-var _inherits2 = _interopRequireDefault(require("@babel/runtime/helpers/inherits"));
-
 var _possibleConstructorReturn2 = _interopRequireDefault(require("@babel/runtime/helpers/possibleConstructorReturn"));
-
 var _getPrototypeOf2 = _interopRequireDefault(require("@babel/runtime/helpers/getPrototypeOf"));
-
+var _inherits2 = _interopRequireDefault(require("@babel/runtime/helpers/inherits"));
 var _defineProperty2 = _interopRequireDefault(require("@babel/runtime/helpers/defineProperty"));
-
 var _Table = _interopRequireDefault(require("@material-ui/core/Table"));
-
 var _TableFooter = _interopRequireDefault(require("@material-ui/core/TableFooter"));
-
 var _TableRow = _interopRequireDefault(require("@material-ui/core/TableRow"));
-
 var _LinearProgress = _interopRequireDefault(require("@material-ui/core/LinearProgress"));
-
 var _reactDoubleScrollbar = _interopRequireDefault(require("react-double-scrollbar"));
-
 var React = _interopRequireWildcard(require("react"));
-
 var _components = require("./components");
-
 var _reactBeautifulDnd = require("react-beautiful-dnd");
-
 var _dataManager = _interopRequireDefault(require("./utils/data-manager"));
-
 var _debounce = require("debounce");
-
 var _fastDeepEqual = _interopRequireDefault(require("fast-deep-equal"));
-
 var _core = require("@material-ui/core");
-
 var CommonValues = _interopRequireWildcard(require("./utils/common-values"));
-
-function _createSuper(Derived) { var hasNativeReflectConstruct = _isNativeReflectConstruct(); return function _createSuperInternal() { var Super = (0, _getPrototypeOf2["default"])(Derived), result; if (hasNativeReflectConstruct) { var NewTarget = (0, _getPrototypeOf2["default"])(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return (0, _possibleConstructorReturn2["default"])(this, result); }; }
-
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
-
+function _getRequireWildcardCache(e) { if ("function" != typeof WeakMap) return null; var r = new WeakMap(), t = new WeakMap(); return (_getRequireWildcardCache = function _getRequireWildcardCache(e) { return e ? t : r; })(e); }
+function _interopRequireWildcard(e, r) { if (!r && e && e.__esModule) return e; if (null === e || "object" != _typeof3(e) && "function" != typeof e) return { "default": e }; var t = _getRequireWildcardCache(r); if (t && t.has(e)) return t.get(e); var n = { __proto__: null }, a = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var u in e) if ("default" !== u && {}.hasOwnProperty.call(e, u)) { var i = a ? Object.getOwnPropertyDescriptor(e, u) : null; i && (i.get || i.set) ? Object.defineProperty(n, u, i) : n[u] = e[u]; } return n["default"] = e, t && t.set(e, n), n; }
+function _callSuper(t, o, e) { return o = (0, _getPrototypeOf2["default"])(o), (0, _possibleConstructorReturn2["default"])(t, _isNativeReflectConstruct() ? Reflect.construct(o, e || [], (0, _getPrototypeOf2["default"])(t).constructor) : o.apply(t, e)); }
+function _isNativeReflectConstruct() { try { var t = !Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); } catch (t) {} return (_isNativeReflectConstruct = function _isNativeReflectConstruct() { return !!t; })(); } /* eslint-disable no-unused-vars */
 /* eslint-enable no-unused-vars */
-var MaterialTable = /*#__PURE__*/function (_React$Component) {
-  (0, _inherits2["default"])(MaterialTable, _React$Component);
-
-  var _super = _createSuper(MaterialTable);
-
+var MaterialTable = exports["default"] = /*#__PURE__*/function (_React$Component) {
   function MaterialTable(_props) {
     var _this;
-
     (0, _classCallCheck2["default"])(this, MaterialTable);
-    _this = _super.call(this, _props);
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "dataManager", new _dataManager["default"]());
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "isRemoteData", function (props) {
+    _this = _callSuper(this, MaterialTable, [_props]);
+    (0, _defineProperty2["default"])(_this, "dataManager", new _dataManager["default"]());
+    (0, _defineProperty2["default"])(_this, "isRemoteData", function (props) {
       return !Array.isArray((props || _this.props).data);
     });
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "isOutsidePageNumbers", function (props) {
+    (0, _defineProperty2["default"])(_this, "isOutsidePageNumbers", function (props) {
       return props.page !== undefined && props.totalCount !== undefined;
     });
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "onAllSelected", function (checked) {
+    (0, _defineProperty2["default"])(_this, "onAllSelected", function (checked) {
       _this.dataManager.changeAllSelected(checked);
-
       _this.setState(_this.dataManager.getRenderState(), function () {
         return _this.onSelectionChange();
       });
     });
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "onChangeColumnHidden", function (column, hidden) {
+    (0, _defineProperty2["default"])(_this, "onChangeColumnHidden", function (column, hidden) {
       _this.dataManager.changeColumnHidden(column, hidden);
-
       _this.setState(_this.dataManager.getRenderState(), function () {
         _this.props.onChangeColumnHidden && _this.props.onChangeColumnHidden(column, hidden);
       });
     });
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "onChangeGroupOrder", function (groupedColumn) {
+    (0, _defineProperty2["default"])(_this, "onChangeGroupOrder", function (groupedColumn) {
       _this.dataManager.changeGroupOrder(groupedColumn.tableData.id);
-
       _this.setState(_this.dataManager.getRenderState());
     });
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "onChangeOrder", function (orderBy, orderDirection) {
+    (0, _defineProperty2["default"])(_this, "onChangeOrder", function (orderBy, orderDirection) {
       var newOrderBy = orderDirection === "" ? -1 : orderBy;
-
       _this.dataManager.changeOrder(newOrderBy, orderDirection);
-
       if (_this.isRemoteData()) {
         var query = (0, _objectSpread2["default"])({}, _this.state.query);
         query.page = 0;
@@ -110,7 +72,6 @@ var MaterialTable = /*#__PURE__*/function (_React$Component) {
           return a.tableData.id === newOrderBy;
         });
         query.orderDirection = orderDirection;
-
         _this.onQueryChange(query, function () {
           _this.props.onOrderChange && _this.props.onOrderChange(newOrderBy, orderDirection);
         });
@@ -120,11 +81,10 @@ var MaterialTable = /*#__PURE__*/function (_React$Component) {
         });
       }
     });
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "onChangePage", function (event, page) {
+    (0, _defineProperty2["default"])(_this, "onChangePage", function (event, page) {
       if (_this.isRemoteData()) {
         var query = (0, _objectSpread2["default"])({}, _this.state.query);
         query.page = page;
-
         _this.onQueryChange(query, function () {
           _this.props.onChangePage && _this.props.onChangePage(page, query.pageSize);
         });
@@ -132,52 +92,45 @@ var MaterialTable = /*#__PURE__*/function (_React$Component) {
         if (!_this.isOutsidePageNumbers(_this.props)) {
           _this.dataManager.changeCurrentPage(page);
         }
-
         _this.setState(_this.dataManager.getRenderState(), function () {
           _this.props.onChangePage && _this.props.onChangePage(page, _this.state.pageSize);
         });
       }
     });
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "onChangeRowsPerPage", function (event) {
+    (0, _defineProperty2["default"])(_this, "onChangeRowsPerPage", function (event) {
       var pageSize = event.target.value;
-
       _this.dataManager.changePageSize(pageSize);
-
       _this.props.onChangePage && _this.props.onChangePage(0, pageSize);
-
       if (_this.isRemoteData()) {
         var query = (0, _objectSpread2["default"])({}, _this.state.query);
         query.pageSize = event.target.value;
         query.page = 0;
-
         _this.onQueryChange(query, function () {
           _this.props.onChangeRowsPerPage && _this.props.onChangeRowsPerPage(pageSize);
         });
       } else {
         _this.dataManager.changeCurrentPage(0);
-
         _this.setState(_this.dataManager.getRenderState(), function () {
           _this.props.onChangeRowsPerPage && _this.props.onChangeRowsPerPage(pageSize);
         });
       }
     });
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "onDragEnd", function (result) {
+    (0, _defineProperty2["default"])(_this, "onDragEnd", function (result) {
       if (!result || !result.source || !result.destination) return;
-
       _this.dataManager.changeByDrag(result);
-
-      _this.setState(_this.dataManager.getRenderState(), function () {
+      _this.setState((0, _objectSpread2["default"])({}, _this.dataManager.getRenderState(), {
+        renderCount: (_this.state.renderCount || 0) + 1
+      }), function () {
         if (_this.props.onColumnDragged && result.destination.droppableId === "headers" && result.source.droppableId === "headers") {
           _this.props.onColumnDragged(result.source.index, result.destination.index);
         }
       });
     });
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "onGroupExpandChanged", function (path) {
+    (0, _defineProperty2["default"])(_this, "onGroupExpandChanged", function (path) {
       _this.dataManager.changeGroupExpand(path);
-
       _this.setState(_this.dataManager.getRenderState());
     });
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "onGroupRemoved", function (groupedColumn, index) {
+    (0, _defineProperty2["default"])(_this, "onGroupRemoved", function (groupedColumn, index) {
       var result = {
         combine: null,
         destination: {
@@ -193,14 +146,12 @@ var MaterialTable = /*#__PURE__*/function (_React$Component) {
         },
         type: "DEFAULT"
       };
-
       _this.dataManager.changeByDrag(result);
-
       _this.setState(_this.dataManager.getRenderState(), function () {
         _this.props.onGroupRemoved && _this.props.onGroupRemoved(groupedColumn, index);
       });
     });
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "onEditingApproved", function (mode, newData, oldData) {
+    (0, _defineProperty2["default"])(_this, "onEditingApproved", function (mode, newData, oldData) {
       if (mode === "add" && _this.props.editable && _this.props.editable.onRowAdd) {
         _this.setState({
           isLoading: true
@@ -219,7 +170,6 @@ var MaterialTable = /*#__PURE__*/function (_React$Component) {
               message: reason,
               errorCause: "add"
             };
-
             _this.setState({
               isLoading: false,
               errorState: errorState
@@ -232,7 +182,6 @@ var MaterialTable = /*#__PURE__*/function (_React$Component) {
         }, function () {
           _this.props.editable.onRowUpdate(newData, oldData).then(function (result) {
             _this.dataManager.changeRowEditing(oldData);
-
             _this.setState((0, _objectSpread2["default"])({
               isLoading: false
             }, _this.dataManager.getRenderState()), function () {
@@ -245,7 +194,6 @@ var MaterialTable = /*#__PURE__*/function (_React$Component) {
               message: reason,
               errorCause: "update"
             };
-
             _this.setState({
               isLoading: false,
               errorState: errorState
@@ -258,7 +206,6 @@ var MaterialTable = /*#__PURE__*/function (_React$Component) {
         }, function () {
           _this.props.editable.onRowDelete(oldData).then(function (result) {
             _this.dataManager.changeRowEditing(oldData);
-
             _this.setState((0, _objectSpread2["default"])({
               isLoading: false
             }, _this.dataManager.getRenderState()), function () {
@@ -271,7 +218,6 @@ var MaterialTable = /*#__PURE__*/function (_React$Component) {
               message: reason,
               errorCause: "delete"
             };
-
             _this.setState({
               isLoading: false,
               errorState: errorState
@@ -284,9 +230,7 @@ var MaterialTable = /*#__PURE__*/function (_React$Component) {
         }, function () {
           _this.props.editable.onBulkUpdate(_this.dataManager.bulkEditChangedRows).then(function (result) {
             _this.dataManager.changeBulkEditOpen(false);
-
             _this.dataManager.clearBulkEditChangedRows();
-
             _this.setState((0, _objectSpread2["default"])({
               isLoading: false
             }, _this.dataManager.getRenderState()), function () {
@@ -299,7 +243,6 @@ var MaterialTable = /*#__PURE__*/function (_React$Component) {
               message: reason,
               errorCause: "bulk edit"
             };
-
             _this.setState({
               isLoading: false,
               errorState: errorState
@@ -308,33 +251,28 @@ var MaterialTable = /*#__PURE__*/function (_React$Component) {
         });
       }
     });
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "onEditingCanceled", function (mode, rowData) {
+    (0, _defineProperty2["default"])(_this, "onEditingCanceled", function (mode, rowData) {
       if (mode === "add") {
         _this.props.editable.onRowAddCancelled && _this.props.editable.onRowAddCancelled();
-
         _this.setState({
           showAddRow: false
         });
       } else if (mode === "update") {
         _this.props.editable.onRowUpdateCancelled && _this.props.editable.onRowUpdateCancelled();
-
         _this.dataManager.changeRowEditing(rowData);
-
         _this.setState(_this.dataManager.getRenderState());
       } else if (mode === "delete") {
         _this.dataManager.changeRowEditing(rowData);
-
         _this.setState(_this.dataManager.getRenderState());
       }
     });
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "retry", function () {
+    (0, _defineProperty2["default"])(_this, "retry", function () {
       _this.onQueryChange(_this.state.query);
     });
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "onQueryChange", function (query, callback) {
+    (0, _defineProperty2["default"])(_this, "onQueryChange", function (query, callback) {
       query = (0, _objectSpread2["default"])({}, _this.state.query, query, {
         error: _this.state.errorState
       });
-
       _this.setState({
         isLoading: true,
         errorState: undefined
@@ -342,9 +280,7 @@ var MaterialTable = /*#__PURE__*/function (_React$Component) {
         _this.props.data(query).then(function (result) {
           query.totalCount = result.totalCount;
           query.page = result.page;
-
           _this.dataManager.setData(result.data);
-
           _this.setState((0, _objectSpread2["default"])({
             isLoading: false,
             errorState: false
@@ -359,7 +295,6 @@ var MaterialTable = /*#__PURE__*/function (_React$Component) {
             message: (0, _typeof2["default"])(error) === "object" ? error.message : error !== undefined ? error : localization.error,
             errorCause: "query"
           };
-
           _this.setState((0, _objectSpread2["default"])({
             isLoading: false,
             errorState: errorState
@@ -367,17 +302,15 @@ var MaterialTable = /*#__PURE__*/function (_React$Component) {
         });
       });
     });
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "onRowSelected", function (event, path, dataClicked) {
+    (0, _defineProperty2["default"])(_this, "onRowSelected", function (event, path, dataClicked) {
       _this.dataManager.changeRowSelected(event.target.checked, path);
-
       _this.setState(_this.dataManager.getRenderState(), function () {
         return _this.onSelectionChange(dataClicked);
       });
     });
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "onSelectionChange", function (dataClicked) {
+    (0, _defineProperty2["default"])(_this, "onSelectionChange", function (dataClicked) {
       if (_this.props.onSelectionChange) {
         var selectedRows = [];
-
         var findSelecteds = function findSelecteds(list) {
           list.forEach(function (row) {
             if (row.tableData.checked) {
@@ -385,18 +318,15 @@ var MaterialTable = /*#__PURE__*/function (_React$Component) {
             }
           });
         };
-
         findSelecteds(_this.state.originalData);
-
         _this.props.onSelectionChange(selectedRows, dataClicked);
       }
     });
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "onSearchChangeDebounce", (0, _debounce.debounce)(function (searchText) {
+    (0, _defineProperty2["default"])(_this, "onSearchChangeDebounce", (0, _debounce.debounce)(function (searchText) {
       if (_this.isRemoteData()) {
         var query = (0, _objectSpread2["default"])({}, _this.state.query);
         query.page = 0;
         query.search = searchText;
-
         _this.onQueryChange(query);
       } else {
         _this.setState(_this.dataManager.getRenderState(), function () {
@@ -404,12 +334,11 @@ var MaterialTable = /*#__PURE__*/function (_React$Component) {
         });
       }
     }, _this.props.options.debounceInterval));
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "onFilterChange", function (columnId, value) {
+    (0, _defineProperty2["default"])(_this, "onFilterChange", function (columnId, value) {
       _this.dataManager.changeFilterValue(columnId, value);
-
       _this.setState({}, _this.onFilterChangeDebounce);
     });
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "onFilterChangeDebounce", (0, _debounce.debounce)(function () {
+    (0, _defineProperty2["default"])(_this, "onFilterChangeDebounce", (0, _debounce.debounce)(function () {
       if (_this.isRemoteData()) {
         var query = (0, _objectSpread2["default"])({}, _this.state.query);
         query.page = 0;
@@ -422,7 +351,6 @@ var MaterialTable = /*#__PURE__*/function (_React$Component) {
             value: a.tableData.filterValue
           };
         });
-
         _this.onQueryChange(query);
       } else {
         _this.setState(_this.dataManager.getRenderState(), function () {
@@ -436,45 +364,38 @@ var MaterialTable = /*#__PURE__*/function (_React$Component) {
                 value: a.tableData.filterValue
               };
             });
-
             _this.props.onFilterChange(appliedFilters);
           }
         });
       }
     }, _this.props.options.debounceInterval));
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "onTreeExpandChanged", function (path, data) {
+    (0, _defineProperty2["default"])(_this, "onTreeExpandChanged", function (path, data) {
       _this.dataManager.changeTreeExpand(path);
-
       _this.setState(_this.dataManager.getRenderState(), function () {
         _this.props.onTreeExpandChange && _this.props.onTreeExpandChange(data, data.tableData.isTreeExpanded);
       });
     });
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "onToggleDetailPanel", function (path, render) {
+    (0, _defineProperty2["default"])(_this, "onToggleDetailPanel", function (path, render) {
       _this.dataManager.changeDetailPanelVisibility(path, render);
-
       _this.setState(_this.dataManager.getRenderState());
     });
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "onCellEditStarted", function (rowData, columnDef) {
+    (0, _defineProperty2["default"])(_this, "onCellEditStarted", function (rowData, columnDef) {
       _this.dataManager.startCellEditable(rowData, columnDef);
-
       _this.setState(_this.dataManager.getRenderState());
     });
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "onCellEditFinished", function (rowData, columnDef) {
+    (0, _defineProperty2["default"])(_this, "onCellEditFinished", function (rowData, columnDef) {
       _this.dataManager.finishCellEditable(rowData, columnDef);
-
       _this.setState(_this.dataManager.getRenderState());
     });
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "onEditRowDataChanged", function (rowData, newData) {
+    (0, _defineProperty2["default"])(_this, "onEditRowDataChanged", function (rowData, newData) {
       _this.dataManager.setEditRowData(rowData, newData);
-
       _this.setState(_this.dataManager.getRenderState());
     });
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "onColumnResized", function (id, additionalWidth) {
+    (0, _defineProperty2["default"])(_this, "onColumnResized", function (id, additionalWidth) {
       _this.dataManager.onColumnResized(id, additionalWidth);
-
       _this.setState(_this.dataManager.getRenderState());
     });
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "renderTable", function (props) {
+    (0, _defineProperty2["default"])(_this, "renderTable", function (props) {
       return /*#__PURE__*/React.createElement(_Table["default"], {
         style: {
           tableLayout: props.options.fixedColumns && (props.options.fixedColumns.left || props.options.fixedColumns.right) ? "fixed" : props.options.tableLayout
@@ -545,27 +466,24 @@ var MaterialTable = /*#__PURE__*/function (_React$Component) {
         scrollWidth: _this.state.width
       }));
     });
-    (0, _defineProperty2["default"])((0, _assertThisInitialized2["default"])(_this), "getColumnsWidth", function (props, count) {
+    (0, _defineProperty2["default"])(_this, "getColumnsWidth", function (props, count) {
       var result = [];
       var actionsWidth = CommonValues.actionsColumnWidth(props);
-
       if (actionsWidth > 0) {
         if (count > 0 && props.options.actionsColumnIndex >= 0 && props.options.actionsColumnIndex < count) {
           result.push(actionsWidth + "px");
         } else if (count < 0 && props.options.actionsColumnIndex < 0 && props.options.actionsColumnIndex >= count) {
           result.push(actionsWidth + "px");
         }
-      } // add selection action width only for left container div
+      }
 
-
+      // add selection action width only for left container div
       if (props.options.selection && count > 0) {
         var selectionWidth = CommonValues.selectionMaxWidth(props, _this.state.treeDataMaxLevel);
         result.push(selectionWidth + "px");
       }
-
       for (var i = 0; i < Math.abs(count) && i < props.columns.length; i++) {
         var colDef = props.columns[count >= 0 ? i : props.columns.length - 1 - i];
-
         if (colDef.tableData) {
           if (typeof colDef.tableData.width === "number") {
             result.push(colDef.tableData.width + "px");
@@ -574,16 +492,11 @@ var MaterialTable = /*#__PURE__*/function (_React$Component) {
           }
         }
       }
-
       return "calc(" + result.join(" + ") + ")";
     });
-
     var calculatedProps = _this.getProps(_props);
-
     _this.setDataManagerFields(calculatedProps, true);
-
     var renderState = _this.dataManager.getRenderState();
-
     _this.state = (0, _objectSpread2["default"])({
       data: [],
       errorState: undefined
@@ -605,7 +518,8 @@ var MaterialTable = /*#__PURE__*/function (_React$Component) {
         page: 0,
         pageSize: calculatedProps.options.pageSize,
         search: renderState.searchText,
-        totalCount: 0
+        totalCount: 0,
+        renderCount: 0
       },
       showAddRow: false,
       bulkEditOpen: false,
@@ -614,12 +528,11 @@ var MaterialTable = /*#__PURE__*/function (_React$Component) {
     _this.tableContainerDiv = React.createRef();
     return _this;
   }
-
-  (0, _createClass2["default"])(MaterialTable, [{
+  (0, _inherits2["default"])(MaterialTable, _React$Component);
+  return (0, _createClass2["default"])(MaterialTable, [{
     key: "componentDidMount",
     value: function componentDidMount() {
       var _this2 = this;
-
       this.setState((0, _objectSpread2["default"])({}, this.dataManager.getRenderState(), {
         width: this.tableContainerDiv.current.scrollWidth
       }), function () {
@@ -633,18 +546,15 @@ var MaterialTable = /*#__PURE__*/function (_React$Component) {
     value: function setDataManagerFields(props, isInit) {
       var defaultSortColumnIndex = -1;
       var defaultSortDirection = "";
-
       if (props && props.options.sorting !== false) {
         defaultSortColumnIndex = props.columns.findIndex(function (a) {
           return a.defaultSort && a.sorting !== false;
         });
         defaultSortDirection = defaultSortColumnIndex > -1 ? props.columns[defaultSortColumnIndex].defaultSort : "";
       }
-
       this.dataManager.setColumns(props.columns);
       this.dataManager.setDefaultExpanded(props.options.defaultExpanded);
       this.dataManager.changeRowEditing();
-
       if (this.isRemoteData(props)) {
         this.dataManager.changeApplySearch(false);
         this.dataManager.changeApplyFilters(false);
@@ -654,9 +564,9 @@ var MaterialTable = /*#__PURE__*/function (_React$Component) {
         this.dataManager.changeApplyFilters(true);
         this.dataManager.changeApplySort(true);
         this.dataManager.setData(props.data);
-      } // If the columns changed and the defaultSorting differs from the current sorting, it will trigger a new sorting
+      }
 
-
+      // If the columns changed and the defaultSorting differs from the current sorting, it will trigger a new sorting
       var shouldReorder = isInit || defaultSortColumnIndex !== this.dataManager.orderBy && !this.isRemoteData() && defaultSortDirection !== this.dataManager.orderDirection;
       shouldReorder && this.dataManager.changeOrder(defaultSortColumnIndex, defaultSortDirection);
       isInit && this.dataManager.changeSearchText(props.options.searchText || "");
@@ -679,25 +589,22 @@ var MaterialTable = /*#__PURE__*/function (_React$Component) {
     key: "componentDidUpdate",
     value: function componentDidUpdate(prevProps) {
       // const propsChanged = Object.entries(this.props).reduce((didChange, prop) => didChange || prop[1] !== prevProps[prop[0]], false);
+
       var fixedPrevColumns = this.cleanColumns(prevProps.columns);
       var fixedPropsColumns = this.cleanColumns(this.props.columns);
       var propsChanged = !(0, _fastDeepEqual["default"])(fixedPrevColumns, fixedPropsColumns);
       propsChanged = propsChanged || !(0, _fastDeepEqual["default"])(prevProps.options, this.props.options);
-
       if (!this.isRemoteData()) {
         propsChanged = propsChanged || !(0, _fastDeepEqual["default"])(prevProps.data, this.props.data);
       }
-
       if (propsChanged) {
         var props = this.getProps(this.props);
         this.setDataManagerFields(props);
         this.setState(this.dataManager.getRenderState());
       }
-
       var count = this.isRemoteData() ? this.state.query.totalCount : this.state.data.length;
       var currentPage = this.isRemoteData() ? this.state.query.page : this.state.currentPage;
       var pageSize = this.isRemoteData() ? this.state.query.pageSize : this.state.pageSize;
-
       if (count <= pageSize * currentPage && currentPage !== 0) {
         this.onChangePage(null, Math.max(0, Math.ceil(count / pageSize) - 1));
       }
@@ -706,7 +613,6 @@ var MaterialTable = /*#__PURE__*/function (_React$Component) {
     key: "getProps",
     value: function getProps(props) {
       var _this3 = this;
-
       var calculatedProps = (0, _objectSpread2["default"])({}, props || this.props);
       calculatedProps.components = (0, _objectSpread2["default"])({}, MaterialTable.defaultProps.components, calculatedProps.components);
       calculatedProps.icons = (0, _objectSpread2["default"])({}, MaterialTable.defaultProps.icons, calculatedProps.icons);
@@ -750,7 +656,6 @@ var MaterialTable = /*#__PURE__*/function (_React$Component) {
           });
         } else return action;
       });
-
       if (calculatedProps.editable) {
         if (calculatedProps.editable.onRowAdd) {
           calculatedProps.actions.push({
@@ -760,14 +665,12 @@ var MaterialTable = /*#__PURE__*/function (_React$Component) {
             disabled: !!this.dataManager.lastEditingRow,
             onClick: function onClick() {
               _this3.dataManager.changeRowEditing();
-
               _this3.setState((0, _objectSpread2["default"])({}, _this3.dataManager.getRenderState(), {
                 showAddRow: !_this3.state.showAddRow
               }));
             }
           });
         }
-
         if (calculatedProps.editable.onRowUpdate) {
           calculatedProps.actions.push(function (rowData) {
             return {
@@ -777,7 +680,6 @@ var MaterialTable = /*#__PURE__*/function (_React$Component) {
               hidden: calculatedProps.editable.isEditHidden && calculatedProps.editable.isEditHidden(rowData),
               onClick: function onClick(e, rowData) {
                 _this3.dataManager.changeRowEditing(rowData, "update");
-
                 _this3.setState((0, _objectSpread2["default"])({}, _this3.dataManager.getRenderState(), {
                   showAddRow: false
                 }));
@@ -785,7 +687,6 @@ var MaterialTable = /*#__PURE__*/function (_React$Component) {
             };
           });
         }
-
         if (calculatedProps.editable.onRowDelete) {
           calculatedProps.actions.push(function (rowData) {
             return {
@@ -795,7 +696,6 @@ var MaterialTable = /*#__PURE__*/function (_React$Component) {
               hidden: calculatedProps.editable.isDeleteHidden && calculatedProps.editable.isDeleteHidden(rowData),
               onClick: function onClick(e, rowData) {
                 _this3.dataManager.changeRowEditing(rowData, "delete");
-
                 _this3.setState((0, _objectSpread2["default"])({}, _this3.dataManager.getRenderState(), {
                   showAddRow: false
                 }));
@@ -803,7 +703,6 @@ var MaterialTable = /*#__PURE__*/function (_React$Component) {
             };
           });
         }
-
         if (calculatedProps.editable.onBulkUpdate) {
           calculatedProps.actions.push({
             icon: calculatedProps.icons.Edit,
@@ -812,7 +711,6 @@ var MaterialTable = /*#__PURE__*/function (_React$Component) {
             hidden: this.dataManager.bulkEditOpen,
             onClick: function onClick() {
               _this3.dataManager.changeBulkEditOpen(true);
-
               _this3.setState(_this3.dataManager.getRenderState());
             }
           });
@@ -832,22 +730,18 @@ var MaterialTable = /*#__PURE__*/function (_React$Component) {
             hidden: !this.dataManager.bulkEditOpen,
             onClick: function onClick() {
               _this3.dataManager.changeBulkEditOpen(false);
-
               _this3.dataManager.clearBulkEditChangedRows();
-
               _this3.setState(_this3.dataManager.getRenderState());
             }
           });
         }
       }
-
       return calculatedProps;
     }
   }, {
     key: "renderFooter",
     value: function renderFooter() {
       var props = this.getProps();
-
       if (props.options.paging) {
         var localization = (0, _objectSpread2["default"])({}, MaterialTable.defaultProps.localization.pagination, this.props.localization.pagination);
         var isOutsidePageNumbers = this.isOutsidePageNumbers(props);
@@ -907,7 +801,6 @@ var MaterialTable = /*#__PURE__*/function (_React$Component) {
     key: "render",
     value: function render() {
       var _this4 = this;
-
       var props = this.getProps();
       return /*#__PURE__*/React.createElement(_reactBeautifulDnd.DragDropContext, {
         onDragEnd: this.onDragEnd,
@@ -964,10 +857,10 @@ var MaterialTable = /*#__PURE__*/function (_React$Component) {
         "double": props.options.doubleHorizontalScroll
       }, /*#__PURE__*/React.createElement(_reactBeautifulDnd.Droppable, {
         droppableId: "headers",
-        direction: "horizontal"
+        direction: "horizontal",
+        key: this.state.renderCount
       }, function (provided, snapshot) {
         var table = _this4.renderTable(props);
-
         return /*#__PURE__*/React.createElement("div", {
           ref: provided.innerRef
         }, /*#__PURE__*/React.createElement("div", {
@@ -1050,11 +943,7 @@ var MaterialTable = /*#__PURE__*/function (_React$Component) {
       }))));
     }
   }]);
-  return MaterialTable;
 }(React.Component);
-
-exports["default"] = MaterialTable;
-
 var style = function style() {
   return {
     horizontalScrollContainer: {
@@ -1072,12 +961,10 @@ var style = function style() {
     }
   };
 };
-
 var ScrollBar = (0, _core.withStyles)(style)(function (_ref) {
   var _double = _ref["double"],
-      children = _ref.children,
-      classes = _ref.classes;
-
+    children = _ref.children,
+    classes = _ref.classes;
   if (_double) {
     return /*#__PURE__*/React.createElement(_reactDoubleScrollbar["default"], null, children);
   } else {

--- a/dist/prop-types.js
+++ b/dist/prop-types.js
@@ -1,24 +1,19 @@
 "use strict";
 
 var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
-
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.propTypes = void 0;
-
 var _propTypes = _interopRequireDefault(require("prop-types"));
-
 var RefComponent = _propTypes["default"].shape({
   current: _propTypes["default"].element
 });
-
 var StyledComponent = _propTypes["default"].shape({
   classes: _propTypes["default"].object,
   innerRef: RefComponent
 });
-
-var propTypes = {
+var propTypes = exports.propTypes = {
   actions: _propTypes["default"].arrayOf(_propTypes["default"].oneOfType([_propTypes["default"].func, _propTypes["default"].shape({
     icon: _propTypes["default"].oneOfType([_propTypes["default"].element, _propTypes["default"].func, _propTypes["default"].string, RefComponent]).isRequired,
     isFreeAction: _propTypes["default"].bool,
@@ -212,4 +207,3 @@ var propTypes = {
   page: _propTypes["default"].number,
   totalCount: _propTypes["default"].number
 };
-exports.propTypes = propTypes;

--- a/dist/utils/common-values.js
+++ b/dist/utils/common-values.js
@@ -3,57 +3,35 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.reducePercentsInCalc = exports.selectionMaxWidth = exports.actionsColumnWidth = exports.rowActions = exports.baseIconSize = exports.elementSize = void 0;
-
-var elementSize = function elementSize(props) {
+exports.selectionMaxWidth = exports.rowActions = exports.reducePercentsInCalc = exports.elementSize = exports.baseIconSize = exports.actionsColumnWidth = void 0;
+var elementSize = exports.elementSize = function elementSize(props) {
   return props.options.padding === "default" ? "medium" : "small";
 };
-
-exports.elementSize = elementSize;
-
-var baseIconSize = function baseIconSize(props) {
+var baseIconSize = exports.baseIconSize = function baseIconSize(props) {
   return elementSize(props) === "medium" ? 48 : 32;
 };
-
-exports.baseIconSize = baseIconSize;
-
-var rowActions = function rowActions(props) {
+var rowActions = exports.rowActions = function rowActions(props) {
   return props.actions.filter(function (a) {
     return a.position === "row" || typeof a === "function";
   });
 };
-
-exports.rowActions = rowActions;
-
-var actionsColumnWidth = function actionsColumnWidth(props) {
+var actionsColumnWidth = exports.actionsColumnWidth = function actionsColumnWidth(props) {
   return rowActions(props).length * baseIconSize(props);
 };
-
-exports.actionsColumnWidth = actionsColumnWidth;
-
-var selectionMaxWidth = function selectionMaxWidth(props, maxTreeLevel) {
+var selectionMaxWidth = exports.selectionMaxWidth = function selectionMaxWidth(props, maxTreeLevel) {
   return baseIconSize(props) + 9 * maxTreeLevel;
 };
-
-exports.selectionMaxWidth = selectionMaxWidth;
-
-var reducePercentsInCalc = function reducePercentsInCalc(calc, fullValue) {
+var reducePercentsInCalc = exports.reducePercentsInCalc = function reducePercentsInCalc(calc, fullValue) {
   var index = calc.indexOf("%");
-
   while (index !== -1) {
     var leftIndex = index - 1;
-
     while (leftIndex >= 0 && "0123456789.".indexOf(calc[leftIndex]) !== -1) {
       leftIndex--;
     }
-
     leftIndex++;
     var value = Number.parseFloat(calc.substring(leftIndex, index));
     calc = calc.substring(0, leftIndex) + value * fullValue / 100 + "px" + calc.substring(index + 1);
     index = calc.indexOf("%");
   }
-
   return calc;
 };
-
-exports.reducePercentsInCalc = reducePercentsInCalc;

--- a/dist/utils/data-manager.js
+++ b/dist/utils/data-manager.js
@@ -1,30 +1,20 @@
 "use strict";
 
 var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
-
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports["default"] = void 0;
-
 var _objectSpread2 = _interopRequireDefault(require("@babel/runtime/helpers/objectSpread"));
-
 var _toConsumableArray2 = _interopRequireDefault(require("@babel/runtime/helpers/toConsumableArray"));
-
 var _classCallCheck2 = _interopRequireDefault(require("@babel/runtime/helpers/classCallCheck"));
-
 var _createClass2 = _interopRequireDefault(require("@babel/runtime/helpers/createClass"));
-
 var _defineProperty2 = _interopRequireDefault(require("@babel/runtime/helpers/defineProperty"));
-
 var _format = _interopRequireDefault(require("date-fns/format"));
-
 var _2 = require("./");
-
-var DataManager = /*#__PURE__*/function () {
+var DataManager = exports["default"] = /*#__PURE__*/function () {
   function DataManager() {
     var _this = this;
-
     (0, _classCallCheck2["default"])(this, DataManager);
     (0, _defineProperty2["default"])(this, "applyFilters", false);
     (0, _defineProperty2["default"])(this, "applySearch", false);
@@ -70,7 +60,6 @@ var DataManager = /*#__PURE__*/function () {
         var index = rowData.tableData.editCellList.findIndex(function (c) {
           return c.tableData.id === columnDef.tableData.id;
         });
-
         if (index !== -1) {
           rowData.tableData.editCellList.splice(index, 1);
         }
@@ -88,14 +77,11 @@ var DataManager = /*#__PURE__*/function () {
     (0, _defineProperty2["default"])(this, "expandTreeForNodes", function (data) {
       data.forEach(function (row) {
         var currentRow = row;
-
         while (_this.parentFunc(currentRow, _this.data)) {
           var parent = _this.parentFunc(currentRow, _this.data);
-
           if (parent) {
             parent.tableData.isTreeExpanded = true;
           }
-
           currentRow = parent;
         }
       });
@@ -114,7 +100,6 @@ var DataManager = /*#__PURE__*/function () {
         var data = {
           groups: renderData
         };
-
         var _node = path.reduce(function (result, current) {
           if (result.groups.length > 0) {
             return result.groups[current];
@@ -124,45 +109,36 @@ var DataManager = /*#__PURE__*/function () {
             return undefined;
           }
         }, data);
-
         return _node;
       }
     });
     (0, _defineProperty2["default"])(this, "getFieldValue", function (rowData, columnDef) {
       var lookup = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : true;
       var value = typeof rowData[columnDef.field] !== "undefined" ? rowData[columnDef.field] : (0, _2.byString)(rowData, columnDef.field);
-
       if (columnDef.lookup && lookup) {
         value = columnDef.lookup[value];
       }
-
       return value;
     });
     (0, _defineProperty2["default"])(this, "getRenderState", function () {
       if (_this.filtered === false) {
         _this.filterData();
       }
-
       if (_this.searched === false) {
         _this.searchData();
       }
-
       if (_this.grouped === false && _this.isDataType("group")) {
         _this.groupData();
       }
-
       if (_this.treefied === false && _this.isDataType("tree")) {
         _this.treefyData();
       }
-
       if (_this.sorted === false) {
         _this.sortData();
       }
-
       if (_this.paged === false) {
         _this.pageData();
       }
-
       return {
         columns: _this.columns,
         currentPage: _this.currentPage,
@@ -183,15 +159,13 @@ var DataManager = /*#__PURE__*/function () {
     (0, _defineProperty2["default"])(this, "filterData", function () {
       _this.searched = _this.grouped = _this.treefied = _this.sorted = _this.paged = false;
       _this.filteredData = (0, _toConsumableArray2["default"])(_this.data);
-
       if (_this.applyFilters) {
         _this.columns.filter(function (columnDef) {
           return columnDef.tableData.filterValue;
         }).forEach(function (columnDef) {
           var lookup = columnDef.lookup,
-              type = columnDef.type,
-              tableData = columnDef.tableData;
-
+            type = columnDef.type,
+            tableData = columnDef.tableData;
           if (columnDef.customFilterAndSearch) {
             _this.filteredData = _this.filteredData.filter(function (row) {
               return !!columnDef.customFilterAndSearch(tableData.filterValue, row, columnDef);
@@ -200,32 +174,26 @@ var DataManager = /*#__PURE__*/function () {
             if (lookup) {
               _this.filteredData = _this.filteredData.filter(function (row) {
                 var value = _this.getFieldValue(row, columnDef, false);
-
                 return !tableData.filterValue || tableData.filterValue.length === 0 || tableData.filterValue.indexOf(value !== undefined && value !== null && value.toString()) > -1;
               });
             } else if (type === "numeric") {
               _this.filteredData = _this.filteredData.filter(function (row) {
                 var value = _this.getFieldValue(row, columnDef);
-
                 return value + "" === tableData.filterValue;
               });
             } else if (type === "boolean" && tableData.filterValue) {
               _this.filteredData = _this.filteredData.filter(function (row) {
                 var value = _this.getFieldValue(row, columnDef);
-
                 return value && tableData.filterValue === "checked" || !value && tableData.filterValue === "unchecked";
               });
             } else if (["date", "datetime"].includes(type)) {
               _this.filteredData = _this.filteredData.filter(function (row) {
                 var value = _this.getFieldValue(row, columnDef);
-
                 var currentDate = value ? new Date(value) : null;
-
                 if (currentDate && currentDate.toString() !== "Invalid Date") {
                   var selectedDate = tableData.filterValue;
                   var currentDateToCompare = "";
                   var selectedDateToCompare = "";
-
                   if (type === "date") {
                     currentDateToCompare = (0, _format["default"])(currentDate, "MM/dd/yyyy");
                     selectedDateToCompare = (0, _format["default"])(selectedDate, "MM/dd/yyyy");
@@ -233,46 +201,37 @@ var DataManager = /*#__PURE__*/function () {
                     currentDateToCompare = (0, _format["default"])(currentDate, "MM/dd/yyyy - HH:mm");
                     selectedDateToCompare = (0, _format["default"])(selectedDate, "MM/dd/yyyy - HH:mm");
                   }
-
                   return currentDateToCompare === selectedDateToCompare;
                 }
-
                 return true;
               });
             } else if (type === "time") {
               _this.filteredData = _this.filteredData.filter(function (row) {
                 var value = _this.getFieldValue(row, columnDef);
-
                 var currentHour = value || null;
-
                 if (currentHour) {
                   var selectedHour = tableData.filterValue;
                   var currentHourToCompare = (0, _format["default"])(selectedHour, "HH:mm");
                   return currentHour === currentHourToCompare;
                 }
-
                 return true;
               });
             } else {
               _this.filteredData = _this.filteredData.filter(function (row) {
                 var value = _this.getFieldValue(row, columnDef);
-
                 return value && value.toString().toUpperCase().includes(tableData.filterValue.toUpperCase());
               });
             }
           }
         });
       }
-
       _this.filtered = true;
     });
     (0, _defineProperty2["default"])(this, "searchData", function () {
       _this.grouped = _this.treefied = _this.sorted = _this.paged = false;
       _this.searchedData = (0, _toConsumableArray2["default"])(_this.filteredData);
-
       if (_this.searchText && _this.applySearch) {
         var trimmedSearchText = _this.searchText.trim();
-
         _this.searchedData = _this.searchedData.filter(function (row) {
           return _this.columns.filter(function (columnDef) {
             return columnDef.searchable === undefined ? !columnDef.hidden : columnDef.searchable;
@@ -281,7 +240,6 @@ var DataManager = /*#__PURE__*/function () {
               return !!columnDef.customFilterAndSearch(trimmedSearchText, row, columnDef);
             } else if (columnDef.field) {
               var value = _this.getFieldValue(row, columnDef);
-
               if (value) {
                 return value.toString().toUpperCase().includes(trimmedSearchText.toUpperCase());
               }
@@ -289,26 +247,21 @@ var DataManager = /*#__PURE__*/function () {
           });
         });
       }
-
       _this.searched = true;
     });
   }
-
-  (0, _createClass2["default"])(DataManager, [{
+  return (0, _createClass2["default"])(DataManager, [{
     key: "setData",
     value: function setData(data) {
       var _this2 = this;
-
       this.selectedCount = 0;
       this.data = data.map(function (row, index) {
         row.tableData = (0, _objectSpread2["default"])({}, row.tableData, {
           id: index
         });
-
         if (row.tableData.checked) {
           _this2.selectedCount++;
         }
-
         return row;
       });
       this.filtered = false;
@@ -332,11 +285,9 @@ var DataManager = /*#__PURE__*/function () {
         }, columnDef.tableData, {
           id: index
         });
-
         if (columnDef.tableData.width !== undefined) {
           usedWidth.push(columnDef.tableData.width);
         }
-
         return columnDef;
       });
       usedWidth = "(" + usedWidth.join(" + ") + ")";
@@ -400,42 +351,35 @@ var DataManager = /*#__PURE__*/function () {
     key: "changeRowSelected",
     value: function changeRowSelected(checked, path) {
       var _this3 = this;
-
       var rowData = this.findDataByPath(this.sortedData, path);
       rowData.tableData.checked = checked;
       this.selectedCount = this.selectedCount + (checked ? 1 : -1);
-
-      var checkChildRows = function checkChildRows(rowData) {
+      var _checkChildRows = function checkChildRows(rowData) {
         if (rowData.tableData.childRows) {
           rowData.tableData.childRows.forEach(function (childRow) {
             if (childRow.tableData.checked !== checked) {
               childRow.tableData.checked = checked;
               _this3.selectedCount = _this3.selectedCount + (checked ? 1 : -1);
             }
-
-            checkChildRows(childRow);
+            _checkChildRows(childRow);
           });
         }
       };
-
-      checkChildRows(rowData);
+      _checkChildRows(rowData);
       this.filtered = false;
     }
   }, {
     key: "changeDetailPanelVisibility",
     value: function changeDetailPanelVisibility(path, render) {
       var rowData = this.findDataByPath(this.sortedData, path);
-
       if ((rowData.tableData.showDetailPanel || "").toString() === render.toString()) {
         rowData.tableData.showDetailPanel = undefined;
       } else {
         rowData.tableData.showDetailPanel = render;
       }
-
       if (this.detailPanelType === "single" && this.lastDetailPanelRow && this.lastDetailPanelRow != rowData) {
         this.lastDetailPanelRow.tableData.showDetailPanel = undefined;
       }
-
       this.lastDetailPanelRow = rowData;
     }
   }, {
@@ -456,11 +400,9 @@ var DataManager = /*#__PURE__*/function () {
     value: function changeRowEditing(rowData, mode) {
       if (rowData) {
         rowData.tableData.editing = mode;
-
         if (this.lastEditingRow && this.lastEditingRow != rowData) {
           this.lastEditingRow.tableData.editing = undefined;
         }
-
         if (mode) {
           this.lastEditingRow = rowData;
         } else {
@@ -480,12 +422,11 @@ var DataManager = /*#__PURE__*/function () {
     key: "changeAllSelected",
     value: function changeAllSelected(checked) {
       var selectedCount = 0;
-
       if (this.isDataType("group")) {
-        var setCheck = function setCheck(data) {
+        var _setCheck = function setCheck(data) {
           data.forEach(function (element) {
             if (element.groups.length > 0) {
-              setCheck(element.groups);
+              _setCheck(element.groups);
             } else {
               element.data.forEach(function (d) {
                 d.tableData.checked = d.tableData.disabled ? false : checked;
@@ -494,8 +435,7 @@ var DataManager = /*#__PURE__*/function () {
             }
           });
         };
-
-        setCheck(this.groupedData);
+        _setCheck(this.groupedData);
       } else {
         this.searchedData.map(function (row) {
           row.tableData.checked = row.tableData.disabled ? false : checked;
@@ -503,7 +443,6 @@ var DataManager = /*#__PURE__*/function () {
         });
         selectedCount = this.searchedData.length;
       }
-
       this.selectedCount = checked ? selectedCount : 0;
     }
   }, {
@@ -520,13 +459,11 @@ var DataManager = /*#__PURE__*/function () {
       var column = this.columns.find(function (c) {
         return c.tableData.id === columnId;
       });
-
       if (column.tableData.groupSort === "asc") {
         column.tableData.groupSort = "desc";
       } else {
         column.tableData.groupSort = "asc";
       }
-
       this.sorted = false;
     }
   }, {
@@ -555,12 +492,10 @@ var DataManager = /*#__PURE__*/function () {
       }).sort(function (col1, col2) {
         return col1.tableData.groupOrder - col2.tableData.groupOrder;
       });
-
       if (result.destination.droppableId === "groups" && result.source.droppableId === "groups") {
         start = Math.min(result.destination.index, result.source.index);
         var end = Math.max(result.destination.index, result.source.index);
         groups = groups.slice(start, end + 1);
-
         if (result.destination.index < result.source.index) {
           // Take last and add as first
           var last = groups.pop();
@@ -568,18 +503,15 @@ var DataManager = /*#__PURE__*/function () {
         } else {
           // Take first and add as last
           var _last = groups.shift();
-
           groups.push(_last);
         }
       } else if (result.destination.droppableId === "groups" && result.source.droppableId === "headers") {
         var newGroup = this.columns.find(function (c) {
           return c.tableData.id == result.draggableId;
         });
-
         if (newGroup.grouping === false || !newGroup.field) {
           return;
         }
-
         groups.splice(result.destination.index, 0, newGroup);
       } else if (result.destination.droppableId === "headers" && result.source.droppableId === "groups") {
         var removeGroup = this.columns.find(function (c) {
@@ -589,10 +521,9 @@ var DataManager = /*#__PURE__*/function () {
         groups.splice(result.source.index, 1);
       } else if (result.destination.droppableId === "headers" && result.source.droppableId === "headers") {
         start = Math.min(result.destination.index, result.source.index);
+        var _end = Math.max(result.destination.index, result.source.index);
 
-        var _end = Math.max(result.destination.index, result.source.index); // get the effective start and end considering hidden columns
-
-
+        // get the effective start and end considering hidden columns
         var sorted = this.columns.sort(function (a, b) {
           return a.tableData.columnOrder - b.tableData.columnOrder;
         }).filter(function (column) {
@@ -600,7 +531,6 @@ var DataManager = /*#__PURE__*/function () {
         });
         var numHiddenBeforeStart = 0;
         var numVisibleBeforeStart = 0;
-
         for (var i = 0; i < sorted.length && numVisibleBeforeStart <= start; i++) {
           if (sorted[i].hidden) {
             numHiddenBeforeStart++;
@@ -608,43 +538,33 @@ var DataManager = /*#__PURE__*/function () {
             numVisibleBeforeStart++;
           }
         }
-
         var effectiveStart = start + numHiddenBeforeStart;
         var effectiveEnd = effectiveStart;
-
         for (var numVisibleInRange = 0; numVisibleInRange < _end - start && effectiveEnd < sorted.length; effectiveEnd++) {
           if (!sorted[effectiveEnd].hidden) {
             numVisibleInRange++;
           }
         }
-
         var colsToMov = sorted.slice(effectiveStart, effectiveEnd + 1);
-
         if (result.destination.index < result.source.index) {
           // Take last and add as first
           var _last2 = colsToMov.pop();
-
           colsToMov.unshift(_last2);
         } else {
           // Take first and add as last
           var _last3 = colsToMov.shift();
-
           colsToMov.push(_last3);
         }
-
         for (var _i = 0; _i < colsToMov.length; _i++) {
           colsToMov[_i].tableData.columnOrder = effectiveStart + _i;
         }
-
         return;
       } else {
         return;
       }
-
       for (var _i2 = 0; _i2 < groups.length; _i2++) {
         groups[_i2].tableData.groupOrder = start + _i2;
       }
-
       this.sorted = this.grouped = false;
     }
   }, {
@@ -657,13 +577,18 @@ var DataManager = /*#__PURE__*/function () {
       var nextColumn = this.columns.find(function (c) {
         return c.tableData.id === id + 1;
       });
-      if (!nextColumn) return; // console.log("S i: " + column.tableData.initialWidth);
+      if (!nextColumn) return;
+
+      // console.log("S i: " + column.tableData.initialWidth);
       // console.log("S a: " + column.tableData.additionalWidth);
       // console.log("S w: " + column.tableData.width);
 
       column.tableData.additionalWidth = additionalWidth;
-      column.tableData.width = "calc(".concat(column.tableData.initialWidth, " + ").concat(column.tableData.additionalWidth, "px)"); // nextColumn.tableData.additionalWidth = -1 * additionalWidth;
+      column.tableData.width = "calc(".concat(column.tableData.initialWidth, " + ").concat(column.tableData.additionalWidth, "px)");
+
+      // nextColumn.tableData.additionalWidth = -1 * additionalWidth;
       // nextColumn.tableData.width = `calc(${nextColumn.tableData.initialWidth} + ${nextColumn.tableData.additionalWidth}px)`;
+
       // console.log("F i: " + column.tableData.initialWidth);
       // console.log("F a: " + column.tableData.additionalWidth);
       // console.log("F w: " + column.tableData.width);
@@ -679,12 +604,11 @@ var DataManager = /*#__PURE__*/function () {
         if (!result) {
           return undefined;
         }
-
         if (result.groupsIndex[current] !== undefined) {
           return result.groups[result.groupsIndex[current]];
         }
-
-        return undefined; // const group = result.groups.find(a => a.value === current);
+        return undefined;
+        // const group = result.groups.find(a => a.value === current);
         // return group;
       }, data);
       return node;
@@ -693,7 +617,6 @@ var DataManager = /*#__PURE__*/function () {
     key: "isDataType",
     value: function isDataType(type) {
       var dataType = "normal";
-
       if (this.parentFunc) {
         dataType = "tree";
       } else if (this.columns.find(function (a) {
@@ -701,7 +624,6 @@ var DataManager = /*#__PURE__*/function () {
       })) {
         dataType = "group";
       }
-
       return type === dataType;
     }
   }, {
@@ -715,7 +637,6 @@ var DataManager = /*#__PURE__*/function () {
           if (!a) return -1;
           if (!b) return 1;
         }
-
         return a < b ? -1 : a > b ? 1 : 0;
       }
     }
@@ -723,12 +644,10 @@ var DataManager = /*#__PURE__*/function () {
     key: "sortList",
     value: function sortList(list) {
       var _this4 = this;
-
       var columnDef = this.columns.find(function (_) {
         return _.tableData.id === _this4.orderBy;
       });
       var result = list;
-
       if (columnDef.customSort) {
         if (this.orderDirection === "desc") {
           result = list.sort(function (a, b) {
@@ -746,14 +665,16 @@ var DataManager = /*#__PURE__*/function () {
           return _this4.sort(_this4.getFieldValue(a, columnDef), _this4.getFieldValue(b, columnDef), columnDef.type);
         });
       }
-
       return result;
     }
+
+    // =====================================================================================================
+    // DATA MANUPULATIONS
+    // =====================================================================================================
   }, {
     key: "groupData",
     value: function groupData() {
       var _this5 = this;
-
       this.sorted = this.paged = false;
       this.groupedDataLength = 0;
       var tmpData = (0, _toConsumableArray2["default"])(this.searchedData);
@@ -766,19 +687,15 @@ var DataManager = /*#__PURE__*/function () {
         var object = result;
         object = groups.reduce(function (o, colDef) {
           var value = currentRow[colDef.field] || (0, _2.byString)(currentRow, colDef.field);
-
           if (colDef.getGroupValue) {
             value = colDef.getGroupValue(value);
           }
-
           var group;
           console.log(o.groupsIndex);
           console.log(value);
-
           if (o.groupsIndex[value] !== undefined) {
             group = o.groups[o.groupsIndex[value]];
           }
-
           if (!group) {
             var path = [].concat((0, _toConsumableArray2["default"])(o.path || []), [value]);
             var oldGroup = _this5.findGroupByGroupPath(_this5.groupedData, path) || {
@@ -795,7 +712,6 @@ var DataManager = /*#__PURE__*/function () {
             o.groups.push(group);
             o.groupsIndex[value] = o.groups.length - 1;
           }
-
           return group;
         }, object);
         object.data.push(currentRow);
@@ -813,79 +729,70 @@ var DataManager = /*#__PURE__*/function () {
     key: "treefyData",
     value: function treefyData() {
       var _this6 = this;
-
       this.sorted = this.paged = false;
       this.data.forEach(function (a) {
         return a.tableData.childRows = null;
       });
       this.treefiedData = [];
       this.treefiedDataLength = 0;
-      this.treeDataMaxLevel = 0; // if filter or search is enabled, collapse the tree
+      this.treeDataMaxLevel = 0;
 
+      // if filter or search is enabled, collapse the tree
       if (this.searchText || this.columns.some(function (columnDef) {
         return columnDef.tableData.filterValue;
       })) {
         this.data.forEach(function (row) {
           row.tableData.isTreeExpanded = false;
-        }); // expand the tree for all nodes present after filtering and searching
+        });
 
+        // expand the tree for all nodes present after filtering and searching
         this.expandTreeForNodes(this.searchedData);
       }
-
-      var addRow = function addRow(rowData) {
+      var _addRow = function addRow(rowData) {
         rowData.tableData.markedForTreeRemove = false;
-
         var parent = _this6.parentFunc(rowData, _this6.data);
-
         if (parent) {
           parent.tableData.childRows = parent.tableData.childRows || [];
-
           if (!parent.tableData.childRows.includes(rowData)) {
             parent.tableData.childRows.push(rowData);
             _this6.treefiedDataLength++;
           }
-
-          addRow(parent);
+          _addRow(parent);
           rowData.tableData.path = [].concat((0, _toConsumableArray2["default"])(parent.tableData.path), [parent.tableData.childRows.length - 1]);
           _this6.treeDataMaxLevel = Math.max(_this6.treeDataMaxLevel, rowData.tableData.path.length);
         } else {
           if (!_this6.treefiedData.includes(rowData)) {
             _this6.treefiedData.push(rowData);
-
             _this6.treefiedDataLength++;
             rowData.tableData.path = [_this6.treefiedData.length - 1];
           }
         }
-      }; // Add all rows initially
+      };
 
-
+      // Add all rows initially
       this.data.forEach(function (rowData) {
-        addRow(rowData);
+        _addRow(rowData);
       });
-
       var markForTreeRemove = function markForTreeRemove(rowData) {
         var pointer = _this6.treefiedData;
         rowData.tableData.path.forEach(function (pathPart) {
           if (pointer.tableData && pointer.tableData.childRows) {
             pointer = pointer.tableData.childRows;
           }
-
           pointer = pointer[pathPart];
         });
         pointer.tableData.markedForTreeRemove = true;
       };
-
-      var traverseChildrenAndUnmark = function traverseChildrenAndUnmark(rowData) {
+      var _traverseChildrenAndUnmark = function traverseChildrenAndUnmark(rowData) {
         if (rowData.tableData.childRows) {
           rowData.tableData.childRows.forEach(function (row) {
-            traverseChildrenAndUnmark(row);
+            _traverseChildrenAndUnmark(row);
           });
         }
-
         rowData.tableData.markedForTreeRemove = false;
-      }; // for all data rows, restore initial expand if no search term is available and remove items that shouldn't be there
+      };
 
-
+      // for all data rows, restore initial expand if no search term is available and remove items that shouldn't be there
       this.data.forEach(function (rowData) {
         if (!_this6.searchText && !_this6.columns.some(function (columnDef) {
           return columnDef.tableData.filterValue;
@@ -895,42 +802,35 @@ var DataManager = /*#__PURE__*/function () {
             rowData.tableData.isTreeExpanded = isExpanded;
           }
         }
-
         var hasSearchMatchedChildren = rowData.tableData.isTreeExpanded;
-
         if (!hasSearchMatchedChildren && _this6.searchedData.indexOf(rowData) < 0) {
           markForTreeRemove(rowData);
         }
-      }); // preserve all children of nodes that are matched by search or filters
-
-      this.data.forEach(function (rowData) {
-        if (_this6.searchedData.indexOf(rowData) > -1) {
-          traverseChildrenAndUnmark(rowData);
-        }
       });
 
-      var traverseTreeAndDeleteMarked = function traverseTreeAndDeleteMarked(rowDataArray) {
+      // preserve all children of nodes that are matched by search or filters
+      this.data.forEach(function (rowData) {
+        if (_this6.searchedData.indexOf(rowData) > -1) {
+          _traverseChildrenAndUnmark(rowData);
+        }
+      });
+      var _traverseTreeAndDeleteMarked = function traverseTreeAndDeleteMarked(rowDataArray) {
         for (var i = rowDataArray.length - 1; i >= 0; i--) {
           var item = rowDataArray[i];
-
           if (item.tableData.childRows) {
-            traverseTreeAndDeleteMarked(item.tableData.childRows);
+            _traverseTreeAndDeleteMarked(item.tableData.childRows);
           }
-
           if (item.tableData.markedForTreeRemove) rowDataArray.splice(i, 1);
         }
       };
-
-      traverseTreeAndDeleteMarked(this.treefiedData);
+      _traverseTreeAndDeleteMarked(this.treefiedData);
       this.treefied = true;
     }
   }, {
     key: "sortData",
     value: function sortData() {
       var _this7 = this;
-
       this.paged = false;
-
       if (this.isDataType("group")) {
         this.sortedData = (0, _toConsumableArray2["default"])(this.groupedData);
         var groups = this.columns.filter(function (col) {
@@ -938,7 +838,6 @@ var DataManager = /*#__PURE__*/function () {
         }).sort(function (col1, col2) {
           return col1.tableData.groupOrder - col2.tableData.groupOrder;
         });
-
         var sortGroups = function sortGroups(list, columnDef) {
           if (columnDef.customSort) {
             return list.sort(columnDef.tableData.groupSort === "desc" ? function (a, b) {
@@ -954,15 +853,13 @@ var DataManager = /*#__PURE__*/function () {
             });
           }
         };
-
         this.sortedData = sortGroups(this.sortedData, groups[0]);
-
-        var sortGroupData = function sortGroupData(list, level) {
+        var _sortGroupData = function sortGroupData(list, level) {
           list.forEach(function (element) {
             if (element.groups.length > 0) {
               var column = groups[level];
               element.groups = sortGroups(element.groups, column);
-              sortGroupData(element.groups, level + 1);
+              _sortGroupData(element.groups, level + 1);
             } else {
               if (_this7.orderBy >= 0 && _this7.orderDirection) {
                 element.data = _this7.sortList(element.data);
@@ -970,50 +867,39 @@ var DataManager = /*#__PURE__*/function () {
             }
           });
         };
-
-        sortGroupData(this.sortedData, 1);
+        _sortGroupData(this.sortedData, 1);
       } else if (this.isDataType("tree")) {
         this.sortedData = (0, _toConsumableArray2["default"])(this.treefiedData);
-
         if (this.orderBy != -1) {
           this.sortedData = this.sortList(this.sortedData);
-
-          var sortTree = function sortTree(list) {
+          var _sortTree = function sortTree(list) {
             list.forEach(function (item) {
               if (item.tableData.childRows) {
                 item.tableData.childRows = _this7.sortList(item.tableData.childRows);
-                sortTree(item.tableData.childRows);
+                _sortTree(item.tableData.childRows);
               }
             });
           };
-
-          sortTree(this.sortedData);
+          _sortTree(this.sortedData);
         }
       } else if (this.isDataType("normal")) {
         this.sortedData = (0, _toConsumableArray2["default"])(this.searchedData);
-
         if (this.orderBy != -1 && this.applySort) {
           this.sortedData = this.sortList(this.sortedData);
         }
       }
-
       this.sorted = true;
     }
   }, {
     key: "pageData",
     value: function pageData() {
       this.pagedData = (0, _toConsumableArray2["default"])(this.sortedData);
-
       if (this.paging) {
         var startIndex = this.currentPage * this.pageSize;
         var endIndex = startIndex + this.pageSize;
         this.pagedData = this.pagedData.slice(startIndex, endIndex);
       }
-
       this.paged = true;
     }
   }]);
-  return DataManager;
 }();
-
-exports["default"] = DataManager;

--- a/dist/utils/index.js
+++ b/dist/utils/index.js
@@ -4,50 +4,34 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.setByString = exports.byString = void 0;
-
-var byString = function byString(o, s) {
+var byString = exports.byString = function byString(o, s) {
   if (!s) {
     return;
   }
-
   s = s.replace(/\[(\w+)\]/g, ".$1"); // convert indexes to properties
-
   s = s.replace(/^\./, ""); // strip a leading dot
-
   var a = s.split(".");
-
   for (var i = 0, n = a.length; i < n; ++i) {
     var x = a[i];
-
     if (o && x in o) {
       o = o[x];
     } else {
       return;
     }
   }
-
   return o;
 };
-
-exports.byString = byString;
-
-var setByString = function setByString(obj, path, value) {
+var setByString = exports.setByString = function setByString(obj, path, value) {
   var schema = obj; // a moving reference to internal objects within obj
 
   path = path.replace(/\[(\w+)\]/g, ".$1"); // convert indexes to properties
-
   path = path.replace(/^\./, ""); // strip a leading dot
-
   var pList = path.split(".");
   var len = pList.length;
-
   for (var i = 0; i < len - 1; i++) {
     var elem = pList[i];
     if (!schema[elem]) schema[elem] = {};
     schema = schema[elem];
   }
-
   schema[pList[len - 1]] = value;
 };
-
-exports.setByString = setByString;

--- a/dist/utils/polyfill/array.find.js
+++ b/dist/utils/polyfill/array.find.js
@@ -5,27 +5,20 @@ Object.defineProperty(Array.prototype, "find", {
     if (this == null) {
       throw new TypeError('"this" is null or not defined');
     }
-
     var o = Object(this);
     var len = o.length >>> 0;
-
     if (typeof predicate !== "function") {
       throw new TypeError("predicate must be a function");
     }
-
     var thisArg = arguments[1];
     var k = 0;
-
     while (k < len) {
       var kValue = o[k];
-
       if (predicate.call(thisArg, kValue, k, o)) {
         return kValue;
       }
-
       k++;
     }
-
     return undefined;
   }
 });

--- a/src/components/m-table-body-row.js
+++ b/src/components/m-table-body-row.js
@@ -16,7 +16,7 @@ export default class MTableBodyRow extends React.Component {
     const mapArr = this.props.columns
       .filter(
         (columnDef) =>
-          !columnDef.hidden && !((columnDef.tableData.groupOrder > -1 && !this.props.options.showGroupedColumnsWhileGrouped))
+          !columnDef.hidden && (this.props.options.showGroupedColumnsWhileGrouped || columnDef.tableData.groupOrder === -1)
       )
       .sort((a, b) => a.tableData.columnOrder - b.tableData.columnOrder)
       .map((columnDef, index) => {

--- a/src/components/m-table-edit-row.js
+++ b/src/components/m-table-edit-row.js
@@ -33,7 +33,7 @@ export default class MTableEditRow extends React.Component {
     const mapArr = this.props.columns
       .filter(
         (columnDef) =>
-            !columnDef.hidden && !((columnDef.tableData.groupOrder > -1 && !this.props.options.showGroupedColumnsWhileGrouped))
+            !columnDef.hidden && (this.props.options.showGroupedColumnsWhileGrouped || columnDef.tableData.groupOrder === -1)
       )
       .sort((a, b) => a.tableData.columnOrder - b.tableData.columnOrder)
       .map((columnDef, index) => {
@@ -267,7 +267,7 @@ export default class MTableEditRow extends React.Component {
     } else {
       const colSpan = this.props.columns.filter(
         (columnDef) =>
-            !columnDef.hidden && !((columnDef.tableData.groupOrder > -1 && !this.props.options.showGroupedColumnsWhileGrouped))
+            !columnDef.hidden && (this.props.options.showGroupedColumnsWhileGrouped || columnDef.tableData.groupOrder === -1)
       ).length;
       columns = [
         <TableCell

--- a/src/components/m-table-filter-row.js
+++ b/src/components/m-table-filter-row.js
@@ -206,7 +206,7 @@ class MTableFilterRow extends React.Component {
     const columns = this.props.columns
       .filter(
         (columnDef) =>
-            !columnDef.hidden && !((columnDef.tableData.groupOrder > -1 && !this.props.options.showGroupedColumnsWhileGrouped))
+            !columnDef.hidden && (this.props.options.showGroupedColumnsWhileGrouped || columnDef.tableData.groupOrder === -1)
       )
       .sort((a, b) => a.tableData.columnOrder - b.tableData.columnOrder)
       .map((columnDef) => (

--- a/src/components/m-table-header.js
+++ b/src/components/m-table-header.js
@@ -99,7 +99,7 @@ export class MTableHeader extends React.Component {
     const mapArr = this.props.columns
       .filter(
         (columnDef) =>
-            !columnDef.hidden && !((columnDef.tableData.groupOrder > -1 && !this.props.options.showGroupedColumnsWhileGrouped))
+            !columnDef.hidden && (this.props.options.showGroupedColumnsWhileGrouped || columnDef.tableData.groupOrder === -1)
       )
       .sort((a, b) => a.tableData.columnOrder - b.tableData.columnOrder)
       .map((columnDef, index) => {
@@ -280,11 +280,6 @@ export class MTableHeader extends React.Component {
   }
 
   render() {
-    // const log = this.props.columns.map(c => c.field + ": " + c.tableData.width + ", " + c.tableData.initialWidth + ", " + c.tableData.additionalWidth).join('\r\n');
-    // console.log("===============================");
-    // console.log(log);
-    // console.log("===============================");
-
     const headers = this.renderHeader();
     if (this.props.hasSelection) {
       headers.splice(0, 0, this.renderSelectionHeader());

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -46,6 +46,7 @@ export default class MaterialTable extends React.Component {
         search: renderState.searchText,
 
         totalCount: 0,
+        renderCount: 0,
       },
       showAddRow: false,
       bulkEditOpen: false,
@@ -408,7 +409,12 @@ export default class MaterialTable extends React.Component {
   onDragEnd = (result) => {
     if (!result || !result.source || !result.destination) return;
     this.dataManager.changeByDrag(result);
-    this.setState(this.dataManager.getRenderState(), () => {
+    this.setState(
+      {
+        ...this.dataManager.getRenderState(), 
+        renderCount: (this.state.renderCount || 0) + 1
+      },
+      () => {
       if (
         this.props.onColumnDragged &&
         result.destination.droppableId === "headers" &&
@@ -1031,7 +1037,7 @@ export default class MaterialTable extends React.Component {
             />
           )}
           <ScrollBar double={props.options.doubleHorizontalScroll}>
-            <Droppable droppableId="headers" direction="horizontal">
+            <Droppable droppableId="headers" direction="horizontal" key={this.state.renderCount}>
               {(provided, snapshot) => {
                 const table = this.renderTable(props);
                 return (

--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -429,19 +429,8 @@ export default class DataManager {
     const nextColumn = this.columns.find((c) => c.tableData.id === id + 1);
     if (!nextColumn) return;
 
-    // console.log("S i: " + column.tableData.initialWidth);
-    // console.log("S a: " + column.tableData.additionalWidth);
-    // console.log("S w: " + column.tableData.width);
-
     column.tableData.additionalWidth = additionalWidth;
     column.tableData.width = `calc(${column.tableData.initialWidth} + ${column.tableData.additionalWidth}px)`;
-
-    // nextColumn.tableData.additionalWidth = -1 * additionalWidth;
-    // nextColumn.tableData.width = `calc(${nextColumn.tableData.initialWidth} + ${nextColumn.tableData.additionalWidth}px)`;
-
-    // console.log("F i: " + column.tableData.initialWidth);
-    // console.log("F a: " + column.tableData.additionalWidth);
-    // console.log("F w: " + column.tableData.width);
   }
 
   expandTreeForNodes = (data) => {
@@ -797,8 +786,6 @@ export default class DataManager {
           }
 
           let group;
-          console.log(o.groupsIndex)
-          console.log(value)
           if (o.groupsIndex[value] !== undefined) {
             group = o.groups[o.groupsIndex[value]];
           }


### PR DESCRIPTION
Fixes the following:

- There was a bug with the "Group By" drag-and-drop column header feature, where the headers could not be used in the "Group By" area more than once.  
  - This was a re-rendering issue and is fixed by adding a `renderCount` key to the `src/material-table.js` file.
- Refactors this logic line:
  - From `!columnDef.hidden && !((columnDef.tableData.groupOrder > -1 && !this.props.options.showGroupedColumnsWhileGrouped))`
  - To `!columnDef.hidden && (this.props.options.showGroupedColumnsWhileGrouped || columnDef.tableData.groupOrder === -1)`
  - In the following files:
    - `src/components/m-table-header.js`
    - `src/components/m-table-filter-row.js`
    - `src/components/m-table-edit-row.js`
    - `src/components/m-table-body-row.js`
  - So that it's easier to read and maintain (e.g., not using double negatives, etc.). 
- Lastly, removes unnecessary console logs that were failing the ES Linter. 