### PR TITLE
Undoes previous logic check changes.

### DIFF
--- a/dist/components/m-table-body-row.js
+++ b/dist/components/m-table-body-row.js
@@ -53,7 +53,7 @@ var MTableBodyRow = exports["default"] = /*#__PURE__*/function (_React$Component
       var _this2 = this;
       var size = CommonValues.elementSize(this.props);
       var mapArr = this.props.columns.filter(function (columnDef) {
-        return !columnDef.hidden && (_this2.props.options.showGroupedColumnsWhileGrouped || columnDef.tableData.groupOrder === -1);
+        return !columnDef.hidden && !(columnDef.tableData.groupOrder > -1 && !_this2.props.options.showGroupedColumnsWhileGrouped);
       }).sort(function (a, b) {
         return a.tableData.columnOrder - b.tableData.columnOrder;
       }).map(function (columnDef, index) {

--- a/dist/components/m-table-edit-row.js
+++ b/dist/components/m-table-edit-row.js
@@ -71,7 +71,7 @@ var MTableEditRow = exports["default"] = /*#__PURE__*/function (_React$Component
       var _this2 = this;
       var size = CommonValues.elementSize(this.props);
       var mapArr = this.props.columns.filter(function (columnDef) {
-        return !columnDef.hidden && (_this2.props.options.showGroupedColumnsWhileGrouped || columnDef.tableData.groupOrder === -1);
+        return !columnDef.hidden && !(columnDef.tableData.groupOrder > -1 && !_this2.props.options.showGroupedColumnsWhileGrouped);
       }).sort(function (a, b) {
         return a.tableData.columnOrder - b.tableData.columnOrder;
       }).map(function (columnDef, index) {
@@ -266,7 +266,7 @@ var MTableEditRow = exports["default"] = /*#__PURE__*/function (_React$Component
         columns = this.renderColumns();
       } else {
         var colSpan = this.props.columns.filter(function (columnDef) {
-          return !columnDef.hidden && (_this4.props.options.showGroupedColumnsWhileGrouped || columnDef.tableData.groupOrder === -1);
+          return !columnDef.hidden && !(columnDef.tableData.groupOrder > -1 && !_this4.props.options.showGroupedColumnsWhileGrouped);
         }).length;
         columns = [/*#__PURE__*/React.createElement(_TableCell["default"], {
           size: size,

--- a/dist/components/m-table-filter-row.js
+++ b/dist/components/m-table-filter-row.js
@@ -209,7 +209,7 @@ var MTableFilterRow = /*#__PURE__*/function (_React$Component) {
     value: function render() {
       var _this2 = this;
       var columns = this.props.columns.filter(function (columnDef) {
-        return !columnDef.hidden && (_this2.props.options.showGroupedColumnsWhileGrouped || columnDef.tableData.groupOrder === -1);
+        return !columnDef.hidden && !(columnDef.tableData.groupOrder > -1 && !_this2.props.options.showGroupedColumnsWhileGrouped);
       }).sort(function (a, b) {
         return a.tableData.columnOrder - b.tableData.columnOrder;
       }).map(function (columnDef) {

--- a/dist/components/m-table-header.js
+++ b/dist/components/m-table-header.js
@@ -95,7 +95,7 @@ var MTableHeader = exports.MTableHeader = /*#__PURE__*/function (_React$Componen
       var _this2 = this;
       var size = this.props.options.padding === "default" ? "medium" : "small";
       var mapArr = this.props.columns.filter(function (columnDef) {
-        return !columnDef.hidden && (_this2.props.options.showGroupedColumnsWhileGrouped || columnDef.tableData.groupOrder === -1);
+        return !columnDef.hidden && !(columnDef.tableData.groupOrder > -1 && !_this2.props.options.showGroupedColumnsWhileGrouped);
       }).sort(function (a, b) {
         return a.tableData.columnOrder - b.tableData.columnOrder;
       }).map(function (columnDef, index) {

--- a/src/components/m-table-body-row.js
+++ b/src/components/m-table-body-row.js
@@ -16,7 +16,7 @@ export default class MTableBodyRow extends React.Component {
     const mapArr = this.props.columns
       .filter(
         (columnDef) =>
-          !columnDef.hidden && (this.props.options.showGroupedColumnsWhileGrouped || columnDef.tableData.groupOrder === -1)
+          !columnDef.hidden && !((columnDef.tableData.groupOrder > -1 && !this.props.options.showGroupedColumnsWhileGrouped))
       )
       .sort((a, b) => a.tableData.columnOrder - b.tableData.columnOrder)
       .map((columnDef, index) => {

--- a/src/components/m-table-edit-row.js
+++ b/src/components/m-table-edit-row.js
@@ -33,7 +33,7 @@ export default class MTableEditRow extends React.Component {
     const mapArr = this.props.columns
       .filter(
         (columnDef) =>
-            !columnDef.hidden && (this.props.options.showGroupedColumnsWhileGrouped || columnDef.tableData.groupOrder === -1)
+          !columnDef.hidden && !((columnDef.tableData.groupOrder > -1 && !this.props.options.showGroupedColumnsWhileGrouped))
       )
       .sort((a, b) => a.tableData.columnOrder - b.tableData.columnOrder)
       .map((columnDef, index) => {
@@ -267,7 +267,7 @@ export default class MTableEditRow extends React.Component {
     } else {
       const colSpan = this.props.columns.filter(
         (columnDef) =>
-            !columnDef.hidden && (this.props.options.showGroupedColumnsWhileGrouped || columnDef.tableData.groupOrder === -1)
+          !columnDef.hidden && !((columnDef.tableData.groupOrder > -1 && !this.props.options.showGroupedColumnsWhileGrouped))
       ).length;
       columns = [
         <TableCell

--- a/src/components/m-table-filter-row.js
+++ b/src/components/m-table-filter-row.js
@@ -206,7 +206,7 @@ class MTableFilterRow extends React.Component {
     const columns = this.props.columns
       .filter(
         (columnDef) =>
-            !columnDef.hidden && (this.props.options.showGroupedColumnsWhileGrouped || columnDef.tableData.groupOrder === -1)
+          !columnDef.hidden && !((columnDef.tableData.groupOrder > -1 && !this.props.options.showGroupedColumnsWhileGrouped))
       )
       .sort((a, b) => a.tableData.columnOrder - b.tableData.columnOrder)
       .map((columnDef) => (

--- a/src/components/m-table-header.js
+++ b/src/components/m-table-header.js
@@ -99,7 +99,7 @@ export class MTableHeader extends React.Component {
     const mapArr = this.props.columns
       .filter(
         (columnDef) =>
-            !columnDef.hidden && (this.props.options.showGroupedColumnsWhileGrouped || columnDef.tableData.groupOrder === -1)
+          !columnDef.hidden && !((columnDef.tableData.groupOrder > -1 && !this.props.options.showGroupedColumnsWhileGrouped))
       )
       .sort((a, b) => a.tableData.columnOrder - b.tableData.columnOrder)
       .map((columnDef, index) => {


### PR DESCRIPTION
Reverts changes made in PR #5, changing `!columnDef.hidden && (this.props.options.showGroupedColumnsWhileGrouped || columnDef.tableData.groupOrder === -1)` back to `!columnDef.hidden && !((columnDef.tableData.groupOrder > -1 && !this.props.options.showGroupedColumnsWhileGrouped)` due to it causing errors in the Inspection Templates page. 